### PR TITLE
ADD: runoff sensitivities to pr and tas (WIP)

### DIFF
--- a/ilamb3/analysis/__init__.py
+++ b/ilamb3/analysis/__init__.py
@@ -3,5 +3,11 @@
 from ilamb3.analysis.bias import bias_analysis
 from ilamb3.analysis.nbp import nbp_analysis
 from ilamb3.analysis.relationship import relationship_analysis
+from ilamb3.analysis.runoff_sensitivity import runoff_sensitivity_analysis
 
-__all__ = ["bias_analysis", "relationship_analysis", "nbp_analysis"]
+__all__ = [
+    "bias_analysis",
+    "nbp_analysis",
+    "relationship_analysis",
+    "runoff_sensitivity_analysis",
+]

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -131,7 +131,7 @@ def compute_runoff_sensitivity(
     return df
 
 
-class runoff_sensitivty_analysis(ILAMBAnalysis):
+class runoff_sensitivity_analysis(ILAMBAnalysis):
     """
     Runoff sensitivity to temperature and precipitation per river basin.
 
@@ -320,7 +320,7 @@ if __name__ == "__main__":
 
     # Initialize the analysis
     ref_file = Path("ref.parquet")
-    analysis = runoff_sensitivty_analysis(
+    analysis = runoff_sensitivity_analysis(
         basin_source="mrb_basins.nc",
         sensitivity_frame=ref_file if ref_file.is_file() else None,
         mrro_source="mrro | LORA",

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -102,10 +102,13 @@ def compute_runoff_sensitivity(
 
         # Take a windowed (decadal) average over the water years
         mean = dsb.rolling(water_year=window_size, center=True).mean()
-        std = dsb.rolling(water_year=window_size, center=True).std()
-        anomaly = (dsb - mean) / std
 
-        # Fit a linear model and compute stats
+        # Compute the anomalies
+        anomaly = mean - mean.mean()
+        anomaly["mrro"] = anomaly["mrro"] / mean["mrro"].mean() * 100.0
+        anomaly["pr"] = anomaly["pr"] / mean["pr"].mean() * 100.0
+
+        # Fit a linear model (with cross term) and compute stats
         results = smf.ols("mrro ~ tas * pr", data=anomaly.to_dataframe()).fit()
         out = {
             f"{key} Sensitivity": val

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -126,8 +126,12 @@ def compute_runoff_sensitivity(
                 if "Intercept" not in key and ":" not in key
             }
         )
-        out["R2"] = results.rsquared
+        out["R2 Cross"] = results.rsquared
         out["Cond"] = results.condition_number
+
+        # Also one without the cross term for comparison
+        results = smf.ols("mrro ~ tas + pr", data=anomaly.to_dataframe()).fit()
+        out["R2"] = results.rsquared
         out["basin"] = str(basin)
         df.append(out)
     df = pd.DataFrame(df).set_index("basin")
@@ -210,3 +214,4 @@ if __name__ == "__main__":
     ds = ds.sel({"time": slice("1905-01-01", "2005-01-01")})
 
     df = compute_runoff_sensitivity(ds, basins[:2])
+    print(df.transpose())

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -7,13 +7,11 @@ ILAMBAnalysis : The abstract base class from which this derives.
 """
 
 from pathlib import Path
-from typing import Union
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import statsmodels.formula.api as smf
 import xarray as xr
-from tqdm import tqdm
 
 import ilamb3
 import ilamb3.dataset as dset
@@ -92,10 +90,7 @@ def compute_runoff_sensitivity(
 
     # Loop over basins and build up the dataframe of sensitivities
     df = []
-    for basin in tqdm(
-        basins, desc="Computing basin sensitivities", unit="basins", disable=quiet
-    ):
-
+    for basin in basins:
         # Compute the regional mean values per basin
         dsb = ilamb_regions.restrict_to_region(ds, basin)
         msr = dsb["cell_measures"].fillna(0)
@@ -163,11 +158,11 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
 
     def __init__(
         self,
-        basin_source: Union[str, Path],
-        sensitivity_frame: Union[None, str, pd.DataFrame] = None,
-        mrro_source: Union[str, Path] = None,
-        tas_source: Union[str, Path] = None,
-        pr_source: Union[str, Path] = None,
+        basin_source: str | Path,
+        sensitivity_frame: None | str | pd.DataFrame = None,
+        mrro_source: str | Path = None,
+        tas_source: str | Path = None,
+        pr_source: str | Path = None,
         timestamp_start: str = "1940-10-01",
         timestamp_end: str = "2014-10-01",
     ):  # numpydoc ignore=GL08
@@ -221,7 +216,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
         return ["pr", "tas", "mrro"]
 
     def __call__(
-        self, ref: xr.Dataset, com: xr.Dataset, basins: Union[list[str], None] = None
+        self, ref: xr.Dataset, com: xr.Dataset, basins: list[str] | None = None
     ) -> tuple[pd.DataFrame, xr.Dataset, xr.Dataset]:
         """
         Apply the ILAMB bias methodology on the given datasets.
@@ -315,7 +310,6 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
 
 
 if __name__ == "__main__":
-
     from ilamb3.models import ModelESGF
 
     # Initialize the analysis

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -1,0 +1,179 @@
+"""
+Blah.
+
+See Also
+--------
+ILAMBAnalysis : The abstract base class from which this derives.
+"""
+
+import pandas as pd
+import statsmodels.formula.api as smf
+import xarray as xr
+from tqdm import tqdm
+
+import ilamb3.dataset as dset
+from ilamb3.analysis.base import ILAMBAnalysis
+from ilamb3.exceptions import MissingRegion, MissingVariable
+
+
+def compute_runoff_sensitivity(
+    ds: xr.Dataset, basins: list[str], window_size: int = 9, quiet: bool = False
+) -> pd.DataFrame:
+    """
+    Compute the runoff sensitivites in the basins provided.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset containing `mrro` (runoff), `pr` (precip), and `tas` (temperature).
+    basins : list[str]
+        The basins in which to compute sensitivities. These should refer to labels
+        that have been registered in the ilamb3.regions.Regions class.
+    window_size : int
+        The number of water years to use in the windowed average.
+    quiet : bool, default False
+        Enable to suppress the progress bar.
+
+    Returns
+    -------
+    pd.DataFrame
+        A dataframe with the sensitivities over each basin.
+    """
+    # Check that the required variables are present
+    required_vars = ["mrro", "tas", "pr"]
+    missing = set(required_vars) - set(ds)
+    if missing:
+        raise MissingVariable(f"Input dataset is lacking variables: {missing}")
+
+    # Check that the basins are in fact registed in the ilamb system
+    ilamb_regions = Regions()
+    missing = set(basins) - set(ilamb_regions.regions)
+    if missing:
+        raise MissingRegion(f"Input basins are not registered as regions: {missing}")
+
+    # Compute the water year for the time series (beginning of year is Oct)
+    t = ds[dset.get_dim_name(ds, "time")]
+    ds["water_year"] = xr.where(t.dt.month > 9, t.dt.year, t.dt.year - 1)
+    ds = ds.set_coords("water_year")
+
+    # Associate cell/time measures with the dataset if not present
+    if "cell_measures" not in ds:
+        ds["cell_measures"] = dset.compute_cell_measures(ds).pint.dequantify()
+    if "time_measures" not in ds:
+        ds["time_measures"] = dset.compute_time_measures(ds).pint.dequantify()
+
+    # Loop over basins and build up the dataframe of sensitivities
+    df = []
+    for basin in tqdm(
+        basins, desc="Computing basin sensitivities", unit="basins", disable=quiet
+    ):
+
+        # Compute the regional mean values per basin
+        dsb = ilamb_regions.restrict_to_region(ds, basin)
+        msr = dsb["cell_measures"].fillna(0)
+        dsb = dsb.drop_vars(
+            [v for v in ds.data_vars if v not in required_vars + ["time_measures"]]
+        )
+        dsb = dsb.weighted(msr).mean(dim=space)
+
+        # Averages per water year. This is weighted by the number of days per month in
+        # each water year. The `groupby`` does not work with the `weighted` accessor and
+        # so we take the weighted mean by hand.
+        dsb = (
+            (dsb * dsb["time_measures"]).groupby("water_year").sum()
+            / dsb["time_measures"].groupby("water_year").sum()
+        ).drop_vars("time_measures")
+
+        # Take a windowed (decadal) average over the water years
+        dsb = dsb.rolling(water_year=window_size, center=True).mean()
+
+        #
+
+        # Fit a linear model and compute stats
+        results = smf.ols("mrro ~ tas + pr", data=dsb.to_dataframe()).fit()
+        tqdm.write(str(results.summary()))
+
+        out = results.params.to_dict()
+        out["basin"] = str(basin)
+        df.append(out)
+    df = pd.DataFrame(df).set_index("basin")
+    return df
+
+
+class runoff_sensitivty_analysis(ILAMBAnalysis):
+    """
+    Blah.
+
+    Methods
+    -------
+    required_variables
+        What variables are required.
+    __call__
+        The method
+    """
+
+    def required_variables(self) -> list[str]:
+        """
+        Return the variable names required in this analysis.
+
+        Returns
+        -------
+        list
+            A list of the required variables, here always [pr, tas, hfls, mrro].
+        """
+        return ["pr", "tas", "hfls", "mrro"]
+
+    def __call__(
+        self,
+        ref: xr.Dataset,
+        com: xr.Dataset,
+    ) -> tuple[pd.DataFrame, xr.Dataset, xr.Dataset]:
+        """
+        Apply the ILAMB bias methodology on the given datasets.
+
+        Parameters
+        ----------
+        ref : xr.Dataset
+            The reference dataset.
+        com : xr.Dataset
+            The comparison dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe with scalar and score information from the comparison.
+        xr.Dataset
+            A dataset containing reference grided information from the comparison.
+        xr.Dataset
+            A dataset containing comparison grided information from the comparison.
+        """
+        # Ensure we have the variables we need for this confrontation
+        missing = set(self.required_variables()) - set(com)
+        if missing:
+            raise MissingVariable(f"Comparison dataset is lacking variables: {missing}")
+
+
+if __name__ == "__main__":
+    # Temporary for some simple testing, using a coarse model for speed of execution
+    import ilamb3
+    from ilamb3.models import ModelESGF
+    from ilamb3.regions import Regions
+
+    # grab some sample basins, still need to encode the right ones. Also have to fix
+    # ilamb to read this without fixes you see here.
+    ilamb_regions = Regions()
+    basins = ilamb3.ilamb_catalog()["river_basins | Dai"].read()
+    basins = basins.rename(dict(basin_index="ids", label="name"))
+    basins["label"] = basins["name"].str.lower()
+    basins["ids"].attrs = {"names": "name", "labels": "label"}
+    basins = ilamb_regions.add_netcdf(basins)
+
+    m = ModelESGF("CanESM5", "r1i1p1f1", "gn")
+    ds = xr.merge([m.get_variable(v) for v in ["mrro", "tas", "pr"]], compat="override")
+    space = [dset.get_dim_name(ds, "lat"), dset.get_dim_name(ds, "lon")]
+
+    # select a time span, probably needs to come from the observations instead of hard
+    # code
+    ds = ds.sel({"time": slice("1905-01-01", "2005-01-01")})
+
+    df = compute_runoff_sensitivity(ds, basins[:1])

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -6,18 +6,27 @@ See Also
 ILAMBAnalysis : The abstract base class from which this derives.
 """
 
+from pathlib import Path
+from typing import Union
+
 import pandas as pd
 import statsmodels.formula.api as smf
 import xarray as xr
 from tqdm import tqdm
 
+import ilamb3
 import ilamb3.dataset as dset
 from ilamb3.analysis.base import ILAMBAnalysis
 from ilamb3.exceptions import MissingRegion, MissingVariable
+from ilamb3.regions import Regions
 
 
 def compute_runoff_sensitivity(
-    ds: xr.Dataset, basins: list[str], window_size: int = 9, quiet: bool = False
+    ds: xr.Dataset,
+    basins: list[str],
+    window_size: int = 9,
+    use_cross: bool = True,
+    quiet: bool = False,
 ) -> pd.DataFrame:
     """
     Compute the runoff sensitivites in the basins provided.
@@ -27,10 +36,13 @@ def compute_runoff_sensitivity(
     ds : xr.Dataset
         The dataset containing `mrro` (runoff), `pr` (precip), and `tas` (temperature).
     basins : list[str]
-        The basins in which to compute sensitivities. These should refer to labels
-        that have been registered in the ilamb3.regions.Regions class.
+        The basins in which to compute sensitivities. These should refer to labels that
+        have been registered in the ilamb3.regions.Regions class.
     window_size : int
         The number of water years to use in the windowed average.
+    use_cross : bool
+        Enable to use the cross term `1 + pr + tas + pr * tas` sensitivities, otherwise
+        use those from a `1 + pr + tas` least squares fit.
     quiet : bool, default False
         Enable to suppress the progress bar.
 
@@ -52,13 +64,16 @@ def compute_runoff_sensitivity(
         raise MissingRegion(f"Input basins are not registered as regions: {missing}")
 
     # Associate cell/time measures with the dataset if not present
+    ds = dset.shift_lon(ds)
     space = [dset.get_dim_name(ds, "lat"), dset.get_dim_name(ds, "lon")]
     if "cell_measures" not in ds:
         ds["cell_measures"] = dset.compute_cell_measures(ds).pint.dequantify()
     if "time_measures" not in ds:
         ds["time_measures"] = dset.compute_time_measures(ds).pint.dequantify()
-        if "time_bnds" in ds:
-            ds = ds.drop_vars("time_bnds")
+        if "bounds" in ds[dset.get_dim_name(ds, "time")].attrs:
+            bnds = ds[dset.get_dim_name(ds, "time")].attrs["bounds"]
+            if bnds in ds:
+                ds = ds.drop_vars(bnds)
 
     # Compute the water year for the time series (beginning of year is Oct)
     t = ds[dset.get_dim_name(ds, "time")]
@@ -96,17 +111,18 @@ def compute_runoff_sensitivity(
         # Fit a linear model (with and without the cross term) and compute stats
         model = smf.ols("mrro ~ tas + pr", data=anomaly.to_dataframe()).fit()
         model_cross = smf.ols("mrro ~ tas * pr", data=anomaly.to_dataframe()).fit()
+        focus = model_cross if use_cross else model
         out = {
             "basin": basin,
-            "tas Sensitivity": model.params.to_dict()["tas"],
-            "tas Low": model.conf_int()[0].to_dict()["tas"],
-            "tas High": model.conf_int()[1].to_dict()["tas"],
-            "pr Sensitivity": model.params.to_dict()["pr"],
-            "pr Low": model.conf_int()[0].to_dict()["pr"],
-            "pr High": model.conf_int()[1].to_dict()["pr"],
+            "tas Sensitivity": focus.params.to_dict()["tas"],
+            "tas Low": focus.conf_int()[0].to_dict()["tas"],
+            "tas High": focus.conf_int()[1].to_dict()["tas"],
+            "pr Sensitivity": focus.params.to_dict()["pr"],
+            "pr Low": focus.conf_int()[0].to_dict()["pr"],
+            "pr High": focus.conf_int()[1].to_dict()["pr"],
             "R2": model.rsquared,
             "R2 Cross": model_cross.rsquared,
-            "Cond": model.condition_number,
+            "Cond": focus.condition_number,
         }
         df.append(out)
     df = pd.DataFrame(df).set_index("basin")
@@ -117,6 +133,24 @@ class runoff_sensitivty_analysis(ILAMBAnalysis):
     """
     Runoff sensitivity to temperature and precipitation per river basin.
 
+    Parameters
+    ----------
+    basin_source : str
+        The source file for the basins to use in the analysis.
+    sensitivity_frame : pd.DataFrame, optional
+        The reference sensitivities. If not provided, we will compute them from the
+        sources provided.
+    mrro_source : str
+        The source of runoff (mrro), required if no sensitivities are provided.
+    tas_source : str
+        The source of temperature (tas), required if no sensitivities are provided.
+    pr_source : str
+        The source of precipitation (pr), required if no sensitivities are provided.
+    timestamp_start : str
+        The initial time over which we compute comparison sensitivities.
+    timestamp_end : str
+        The final time over which we compute comparison sensitivities.
+
     Methods
     -------
     required_variables
@@ -124,6 +158,54 @@ class runoff_sensitivty_analysis(ILAMBAnalysis):
     __call__
         The method
     """
+
+    def __init__(
+        self,
+        basin_source: Union[str, Path],
+        sensitivity_frame: Union[None, str, pd.DataFrame] = None,
+        mrro_source: Union[str, Path] = None,
+        tas_source: Union[str, Path] = None,
+        pr_source: Union[str, Path] = None,
+        timestamp_start: str = "1940-10-01",
+        timestamp_end: str = "2014-10-01",
+    ):  # numpydoc ignore=GL08
+        # Consistency checks
+        cat = ilamb3.ilamb_catalog()
+        self.sources = []
+        if sensitivity_frame is None:
+            if [src for src in [mrro_source, tas_source, pr_source] if src is None]:
+                raise ValueError(
+                    f"If sensitivities are not provided, you must give a source for each variable. Found {mrro_source=} {tas_source=} {pr_source=}"
+                )
+            for src in [mrro_source, tas_source, pr_source]:
+                if Path(src).is_file():
+                    self.sources.append(xr.open_dataset(src))
+                elif src in cat:
+                    self.sources.append(cat[src].read())
+                else:
+                    raise ValueError(f"Could not load source file {src=}")
+
+        # Load/store the sensitivities if present
+        self.sensitivity_frame = sensitivity_frame
+        if sensitivity_frame is not None:
+            read = Path(sensitivity_frame).suffix.replace(".", "read_")
+            if read not in dir(pd):
+                raise OSError(f"Cannot read sensitivty file: {sensitivity_frame}")
+            read = pd.__dict__[read]
+            self.sensitivity_frame = read(sensitivity_frame)
+
+        # Register basins in the ILAMB region system
+        ilamb_regions = Regions()
+        if Path(basin_source).is_file():
+            self.basins = ilamb_regions.add_netcdf(basin_source)
+        elif isinstance(basin_source, str) and basin_source in cat:
+            self.basins = ilamb_regions(cat[basin_source].read())
+        else:
+            raise ValueError(f"Unable to ingest {basin_source=} as ILAMB regions.")
+
+        # Record timestamp variables
+        self.timestamp_start = timestamp_start
+        self.timestamp_end = timestamp_end
 
     def required_variables(self) -> list[str]:
         """
@@ -137,12 +219,7 @@ class runoff_sensitivty_analysis(ILAMBAnalysis):
         return ["pr", "tas", "mrro"]
 
     def __call__(
-        self,
-        ref: xr.Dataset,
-        com: xr.Dataset,
-        basins: list[str],
-        timestamp_start: str = "1905-01-01",
-        timestamp_end: str = "2005-01-01",
+        self, ref: xr.Dataset, com: xr.Dataset, basins: Union[list[str], None] = None
     ) -> tuple[pd.DataFrame, xr.Dataset, xr.Dataset]:
         """
         Apply the ILAMB bias methodology on the given datasets.
@@ -150,16 +227,13 @@ class runoff_sensitivty_analysis(ILAMBAnalysis):
         Parameters
         ----------
         ref : xr.Dataset
-            The reference dataset.
+            Not used in this analysis object.
         com : xr.Dataset
             The comparison dataset.
-        basins : list[str]
-            The basins in which to compute sensitivities. These should refer to labels
-            that have been registered in the ilamb3.regions.Regions class.
-        timestamp_start : str
-            The initial time for which to compute comparision sensitivities.
-        timestamp_end : str
-            The final time for which to compute comparision sensitivities.
+        basins : list[str], optional
+            The basins in which to compute sensitivities. By default will use all those
+            present in the provided `basin_source` but a subset can be provided here if
+            desired.
 
         Returns
         -------
@@ -174,27 +248,61 @@ class runoff_sensitivty_analysis(ILAMBAnalysis):
         missing = set(self.required_variables()) - set(com)
         if missing:
             raise MissingVariable(f"Comparison dataset is lacking variables: {missing}")
+        basins = self.basins if basins is None else basins
 
-        com = com.sel({"time": slice(timestamp_start, timestamp_end)})
+        # Optionally compute reference sensitivities if not given
+        if self.sensitivity_frame is None:
+            ref = xr.merge(self.sources)
+            self.sensitivity_frame = compute_runoff_sensitivity(ref, basins)
+        df_ref = self.sensitivity_frame
+
+        # Compute comparisons sensitivities
+        com = com.sel({"time": slice(self.timestamp_start, self.timestamp_end)})
         df_com = compute_runoff_sensitivity(com, basins)
 
-        return df_com, xr.Dataset(), xr.Dataset()
+        # Paint by the numbers to create maps of scalars
+        ilamb_regions = Regions()
+
+        def _df_to_ds(df):  # numpydoc ignore=GL08
+            ds = xr.Dataset(
+                {
+                    key: ilamb_regions.region_scalars_to_map(df[key].to_dict())
+                    for key in df.columns
+                }
+            )
+            return ds
+
+        ds_ref = _df_to_ds(df_ref)
+        ds_com = _df_to_ds(df_com)
+
+        return df_com, ds_ref, ds_com
 
 
 if __name__ == "__main__":
-    # Temporary for some simple testing, using a coarse model for speed of execution
+
     from ilamb3.models import ModelESGF
-    from ilamb3.regions import Regions
 
-    # Register the MRB basins with the ilamb system
-    ilamb_regions = Regions()
-    basins = ilamb_regions.add_netcdf("mrb_basins.nc")
+    # Initialize the analysis
+    ref_file = Path("ref.parquet")
+    analysis = runoff_sensitivty_analysis(
+        basin_source="mrb_basins.nc",
+        sensitivity_frame=ref_file if ref_file.is_file() else None,
+        mrro_source="mrro | LORA",
+        tas_source="tas | CRU4.02",
+        pr_source="pr | GPCPv2.3",
+    )
 
-    # Test again CanESM5
+    # Test against CanESM5
     m = ModelESGF("CanESM5", "r1i1p1f1", "gn")
-    ds = xr.merge([m.get_variable(v) for v in ["mrro", "tas", "pr"]], compat="override")
+    com = xr.merge(
+        [m.get_variable(v) for v in analysis.required_variables()], compat="override"
+    )
 
-    # Select a time span for the models
-    analysis = runoff_sensitivty_analysis()
-    df, _, _ = analysis(xr.Dataset(), ds, basins)
-    print(df)
+    # Run the analysis
+    df, ds_ref, ds_com = analysis(xr.Dataset(), com)
+    if not ref_file.is_file():
+        analysis.sensitivity_frame.to_parquet(ref_file)
+
+    # Hanjun's numbers for reference:
+    # - tas: -0.61410
+    # - pr: 1.233

--- a/ilamb3/dataset.py
+++ b/ilamb3/dataset.py
@@ -792,3 +792,28 @@ def coarsen_annual(dset: xr.Dataset) -> xr.Dataset:
         f"{time_name}.year"
     ).sum()
     return ann
+
+
+def shift_lon(dset: xr.Dataset) -> xr.Dataset:
+    """
+    Return the dataset with longitudes shifted to [-180,180].
+
+    Parameters
+    ----------
+    dset : xr.Dataset
+        The input dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        The longitude-shifted dataset.
+    """
+    lon_name = get_coord_name(dset, "lon")
+    if (dset[lon_name].min() >= 0) * (dset[lon_name].max() <= 360):
+        dset[lon_name] = (dset[lon_name] + 180) % 360 - 180
+        if "bounds" in dset[lon_name].attrs and dset[lon_name].attrs["bounds"] in dset:
+            dset[dset[lon_name].attrs["bounds"]] = (
+                dset[dset[lon_name].attrs["bounds"]] + 180
+            ) % 360 - 180
+        dset = dset.sortby(lon_name)
+    return dset

--- a/ilamb3/post.py
+++ b/ilamb3/post.py
@@ -30,7 +30,7 @@ def get_plots(ds_ref: xr.Dataset, dsd_com: dict[str, xr.Dataset]) -> list[str]:
     """
     # Which plots do we find in both?
     plots = set(ds_ref)
-    plots.union(*[set(ds) for _, ds in dsd_com.items()])
+    plots = plots.union(*[set(ds) for _, ds in dsd_com.items()])
     return list(plots)
 
 
@@ -71,12 +71,14 @@ def get_plot_limits(
         plots = get_plots(ds_ref, dsd_com)
 
     limits = {key: [] for key in plots}
-    limits = {key: _append_finite(limits[key], ds_ref[key]) for key in ds_ref}
-    limits = {
-        key: _append_finite(limits[key], com[key])
-        for _, com in dsd_com.items()
-        for key in com
-    }
+    limits.update({key: _append_finite(limits[key], ds_ref[key]) for key in ds_ref})
+    limits.update(
+        {
+            key: _append_finite(limits[key], com[key])
+            for _, com in dsd_com.items()
+            for key in com
+        }
+    )
     limits = {
         key: np.quantile(np.hstack(arr), [outlier_fraction, 1 - outlier_fraction])
         for key, arr in limits.items()

--- a/ilamb3/post.py
+++ b/ilamb3/post.py
@@ -1,7 +1,5 @@
 """Post-processing functions used in the ILAMB system."""
 
-from typing import Union
-
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
@@ -37,7 +35,7 @@ def get_plots(ds_ref: xr.Dataset, dsd_com: dict[str, xr.Dataset]) -> list[str]:
 def get_plot_limits(
     ds_ref: xr.Dataset,
     dsd_com: dict[str, xr.Dataset],
-    plots: Union[list[str], None] = None,
+    plots: list[str] | None = None,
     outlier_fraction: float = 0.02,
 ) -> dict[str, np.typing.ArrayLike]:
     """
@@ -193,9 +191,9 @@ def _plot_finalize(ax: plt.Axes) -> plt.Axes:
 
 
 def plot_space(
-    ds: Union[xr.Dataset, xr.DataArray],
-    varname: Union[str, None] = None,
-    region: Union[str, None] = None,
+    ds: xr.Dataset | xr.DataArray,
+    varname: str | None = None,
+    region: str | None = None,
     **kwargs,
 ):
     """

--- a/ilamb3/post.py
+++ b/ilamb3/post.py
@@ -1,0 +1,242 @@
+"""Post-processing functions used in the ILAMB system."""
+
+from typing import Union
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+import ilamb3.dataset as dset
+from ilamb3.regions import Regions
+
+
+def get_plots(ds_ref: xr.Dataset, dsd_com: dict[str, xr.Dataset]) -> list[str]:
+    """
+    Return the union of dataset variables that among all inputs.
+
+    Parameters
+    ----------
+    ds_ref : xr.Dataset
+        The reference dataset.
+    dsd_com : dictionary of xr.Dataset
+        A dictionary of xr.Datasets whose keys are the comparisons (models).
+
+    Returns
+    -------
+    list
+        A list of keys (variables) found in any dataset.
+    """
+    # Which plots do we find in both?
+    plots = set(ds_ref)
+    plots.union(*[set(ds) for _, ds in dsd_com.items()])
+    return list(plots)
+
+
+def get_plot_limits(
+    ds_ref: xr.Dataset,
+    dsd_com: dict[str, xr.Dataset],
+    plots: Union[list[str], None] = None,
+    outlier_fraction: float = 0.02,
+) -> dict[str, np.typing.ArrayLike]:
+    """
+    Return the limits for each plot across all datasets.
+
+    Parameters
+    ----------
+    ds_ref : xr.Dataset
+        The reference dataset.
+    dsd_com : dictionary of xr.Dataset
+        A dictionary of xr.Datasets whose keys are the comparisons (models).
+    plots : list, optional
+        The list of variables (plots) among which to take limits. Defaults to all of
+        them.
+    outlier_fraction : float, optional
+        The fraction of the non-null data across all datasets to consider as outliers.
+        In other words, we will return limits defined by
+        [outlier_fraction,1-outlier_fraction].
+
+    Returns
+    -------
+    dict[str,array]
+        A dictionary who keys are the variable (plot) and entries are the lower and
+        upper plotting limit.
+    """
+
+    def _append_finite(values, da):  # numpydoc ignore=GL08
+        return values + [da.to_numpy().flatten()[np.isfinite(da.to_numpy().flatten())]]
+
+    if plots is None:
+        plots = get_plots(ds_ref, dsd_com)
+
+    limits = {key: [] for key in plots}
+    limits = {key: _append_finite(limits[key], ds_ref[key]) for key in ds_ref}
+    limits = {
+        key: _append_finite(limits[key], com[key])
+        for _, com in dsd_com.items()
+        for key in com
+    }
+    limits = {
+        key: np.quantile(np.hstack(arr), [outlier_fraction, 1 - outlier_fraction])
+        for key, arr in limits.items()
+    }
+    return limits
+
+
+def _plot_extents(da: xr.DataArray) -> np.typing.ArrayLike:
+    """
+    Find the extent of the non-null data.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input data array.
+
+    Returns
+    -------
+    np.typing.ArrayLike
+        The extents as [lonmin, lonmax, latmin, latmax].
+    """
+    lat = xr.where(da.notnull(), da[dset.get_dim_name(da, "lat")], np.nan)
+    lon = xr.where(da.notnull(), da[dset.get_dim_name(da, "lon")], np.nan)
+    return np.array(
+        [
+            float(lon.min()),
+            float(lon.max()),
+            float(lat.min()),
+            float(lat.max()),
+        ]
+    )
+
+
+def _plot_projection(extents) -> tuple[ccrs.Projection, float]:
+    """
+    Given plot extents choose a projection.
+
+    Parameters
+    ----------
+    extents : np.typing.ArrayLike
+        The extents as [lonmin, lonmax, latmin, latmax].
+
+    Returns
+    -------
+    tuple
+        The project and the figure aspect ratio.
+    """
+    if (extents[1] - extents[0]) > 300:
+        aspect_ratio = 2.0
+        proj = ccrs.Robinson(central_longitude=0)
+        if (extents[2] > 0) and (extents[3] > 75):
+            aspect_ratio = 1.0
+            proj = ccrs.Orthographic(central_latitude=+90, central_longitude=0)
+        if (extents[2] < -75) and (extents[3] < 0):
+            aspect_ratio = 1.0
+            proj = ccrs.Orthographic(central_latitude=-90, central_longitude=0)
+    else:
+        aspect_ratio = max(extents[1], extents[0]) - min(extents[1], extents[0])
+        aspect_ratio /= max(extents[3], extents[2]) - min(extents[3], extents[2])
+        proj = ccrs.PlateCarree(central_longitude=extents[:2].mean())
+    return proj, aspect_ratio
+
+
+def _plot_initialize(
+    da: xr.DataArray,
+) -> tuple[np.typing.ArrayLike, float, ccrs.Projection]:
+    """
+    Return initial plot information based on the non-null data range.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input data array.
+
+    Returns
+    -------
+    tuple
+        The plot extents, aspect ratio, and projection.
+    """
+    extents = _plot_extents(da)
+    proj, aspect_ratio = _plot_projection(extents)
+    return extents, aspect_ratio, proj
+
+
+def _plot_finalize(ax: plt.Axes) -> plt.Axes:
+    """
+    Add final touches to the plot.
+
+    Parameters
+    ----------
+    ax : plt.Axes
+        The matplotlib axes object.
+
+    Returns
+    -------
+    plt.Axes
+        The finalized matplotlib object.
+    """
+    ax.add_feature(
+        cfeature.NaturalEarthFeature(
+            "physical", "land", "110m", edgecolor="face", facecolor="0.875"
+        ),
+        zorder=-1,
+    )
+    ax.add_feature(
+        cfeature.NaturalEarthFeature(
+            "physical", "ocean", "110m", edgecolor="face", facecolor="0.750"
+        ),
+        zorder=-1,
+    )
+    return ax
+
+
+def plot_space(
+    ds: Union[xr.Dataset, xr.DataArray],
+    varname: Union[str, None] = None,
+    region: Union[str, None] = None,
+    **kwargs,
+):
+    """
+    Plot the spatial quantity.
+
+    Parameters
+    ----------
+    ds : xr.Dataset or xr.DataArray
+        The input dataset/dataarray.
+    varname : str, optional
+        The variable to plot, must be given if a dataset is passed in.
+    region : str, optional
+        The name of the region over which to plot.
+    **kwargs : dict
+        Additional keyword arguments passed to xr.dataarray.plot().
+
+    Returns
+    -------
+    fig : plt.Figure
+        The matplotlib figure.
+    ax : plt.Axes
+        The matplotlib axes.
+    """
+    # Mask away values outside region
+    ilamb_regions = Regions()
+    if isinstance(ds, xr.Dataset):
+        if varname is None:
+            raise ValueError("Must provide varname if a dataset is passed.")
+        da = ds[varname]
+        if "cell_measures" in ds:
+            da = xr.where(ds["cell_measures"] > 1, da, np.nan, keep_attrs=True)
+    else:
+        da = ds
+    da = ilamb_regions.restrict_to_region(da, region)
+
+    # Plot
+    _, aspect_ratio, proj = _plot_initialize(da)
+    fig, ax = plt.subplots(
+        figsize=(6 * 1.03, 6 / aspect_ratio),
+        subplot_kw={"projection": proj},
+        tight_layout=True,
+        dpi=200,
+    )
+    da.plot(ax=ax, transform=ccrs.PlateCarree(), **kwargs)
+    ax = _plot_finalize(ax)
+    return fig, ax

--- a/ilamb3/tests/test_dataset.py
+++ b/ilamb3/tests/test_dataset.py
@@ -5,10 +5,10 @@ import xarray as xr
 from ilamb3 import dataset as dset
 
 
-def generate_test_dset(seed: int = 1):
+def generate_test_dset(seed: int = 1, shift: bool = False):
     rs = np.random.RandomState(seed)
     lat = [-67.5, -22.5, 22.5, 67.5]
-    lon = [-135.0, -45.0, 45.0, 135.0]
+    lon = [-135.0 + 360 * shift, -45.0 + 360 * shift, 45.0, 135.0]
     time = pd.date_range(start="2000-01-15", periods=5, freq="30D")
     ds = xr.Dataset(
         data_vars={
@@ -175,3 +175,9 @@ def test_is_spatial_or_site():
     ds = generate_test_site_dset()
     assert not dset.is_spatial(ds)
     assert dset.is_site(ds)
+
+
+def test_shift_lon():
+    ds = generate_test_dset(shift=True)
+    ds = dset.shift_lon(ds)
+    assert ds["lon"].min() < -120

--- a/ilamb3/tests/test_post.py
+++ b/ilamb3/tests/test_post.py
@@ -1,0 +1,63 @@
+import cartopy.crs as ccrs
+import numpy as np
+import xarray as xr
+
+from ilamb3 import post
+
+
+def generate_test_dset(seed: int = 1, shift: bool = False):
+    rs = np.random.RandomState(seed)
+    lat = [-67.5, -22.5, 22.5, 67.5]
+    lon = [-135.0 + 360 * shift, -45.0 + 360 * shift, 45.0, 135.0]
+    ds = xr.Dataset(
+        data_vars={
+            "da": xr.DataArray(
+                rs.rand(len(lat), len(lon)) * 1e-8,
+                coords=[lat, lon],
+                dims=["lat", "lon"],
+            ),
+        }
+    )
+    ds["da"].attrs["units"] = "kg m-2 s-1"
+    return ds
+
+
+def generate_test_site_dset(seed: int = 1):
+    rs = np.random.RandomState(seed)
+    lat = xr.DataArray(data=[-67.5, -22.5, 22.5, 67.5], dims=["site"])
+    lon = xr.DataArray(data=[-135.0, -45.0, 45.0, 135.0], dims=["site"])
+    ds = xr.Dataset(
+        data_vars={
+            "da": xr.DataArray(
+                rs.rand(lat.size) * 1e-8,
+                dims=["time", "site"],
+            ),
+        }
+    )
+    ds["da"] = ds["da"].assign_coords({"lat": lat, "lon": lon})
+    ds["da"].attrs["units"] = "kg m-2 s-1"
+    ds["da"].attrs["coordinates"] = "lat lon"
+    return ds
+
+
+def test_get_plot_limits():
+    limits = post.get_plot_limits(
+        generate_test_dset(seed=1).rename_vars({"da": "a"}),
+        {
+            "m": generate_test_dset(seed=1).rename_vars({"da": "b"}),
+            "n": generate_test_dset(seed=1).rename_vars({"da": "c"}),
+        },
+    )
+    assert not (set(limits) - set(["a", "b", "c"]))
+
+
+def test_extents():
+    ds = generate_test_dset()
+    ext = post._plot_extents(ds["da"])
+    assert np.allclose(ext, [-135.0, 135.0, -67.5, 67.5])
+
+
+def test_proj():
+    ds = generate_test_dset()
+    proj = post._plot_projection(post._plot_extents(ds["da"]))
+    assert isinstance(proj[0], ccrs.PlateCarree)

--- a/ilamb3/tests/test_runoff.py
+++ b/ilamb3/tests/test_runoff.py
@@ -1,0 +1,27 @@
+import numpy as np
+import xarray as xr
+
+from ilamb3.analysis.runoff_sensitivity import compute_runoff_sensitivity
+from ilamb3.regions import Regions
+from ilamb3.tests.test_compare import generate_test_dset
+
+
+def test_runoff_sensitivity():
+    ilamb_regions = Regions()
+    ilamb_regions.add_latlon_bounds("test", "test", [-80, 80], [-170, 170])
+    ds = xr.Dataset(
+        {
+            "pr": 1e3 * generate_test_dset(seed=1, ntime=240, nlat=10, nlon=20)["da"],
+            "tas": 273
+            + 1e9 * generate_test_dset(seed=2, ntime=240, nlat=10, nlon=20)["da"],
+            "mrro": generate_test_dset(seed=3, ntime=240, nlat=10, nlon=20)["da"],
+        }
+    )
+    ds["mrro"] = (
+        ds["mrro"].mean()
+        + 1e2 * (ds["pr"] - ds["pr"].mean())
+        + 1e-3 * (ds["tas"] - ds["tas"].mean())
+    )
+    df = compute_runoff_sensitivity(ds, ["test"])
+    assert np.allclose(df.loc["test"]["tas Sensitivity"], 28006.878361)
+    assert np.allclose(df.loc["test"]["pr Sensitivity"], 139.850275)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "cartopy>=0.24.1",
     "pyyaml>=6.0.2",
     "jinja2>=3.1.5",
+    "statsmodels>=0.14.4",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ wheels = [
 
 [[package]]
 name = "ilamb3"
-version = "2024.5.31.post1.dev10+g1997577.d20250128"
+version = "2024.5.31.post1.dev24+gd161f35.d20250129"
 source = { editable = "." }
 dependencies = [
     { name = "cartopy" },
@@ -665,6 +665,7 @@ dependencies = [
     { name = "pooch" },
     { name = "pyyaml" },
     { name = "scipy" },
+    { name = "statsmodels" },
     { name = "xarray" },
 ]
 
@@ -696,6 +697,7 @@ requires-dist = [
     { name = "pooch", specifier = ">=1.8.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scipy", specifier = ">=1.15.1" },
+    { name = "statsmodels", specifier = ">=0.14.4" },
     { name = "xarray", specifier = ">=2025.1.1" },
 ]
 
@@ -1382,6 +1384,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
+name = "patsy"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/81/74f6a65b848ffd16c18f920620ce999fe45fe27f01ab3911260ce4ed85e4/patsy-1.0.1.tar.gz", hash = "sha256:e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4", size = 396010 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/2b/b50d3d08ea0fc419c183a84210571eba005328efa62b6b98bc28e9ead32a/patsy-1.0.1-py2.py3-none-any.whl", hash = "sha256:751fb38f9e97e62312e921a1954b81e1bb2bcda4f5eeabaf94db251ee791509c", size = 232923 },
 ]
 
 [[package]]
@@ -2240,6 +2254,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/3b/963a015dd8ea17e10c7b0e2f14d7c4daec903baf60a017e756b57953a4bf/statsmodels-0.14.4.tar.gz", hash = "sha256:5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67", size = 20354802 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/2c/23bf5ad9e8a77c0c8d9750512bff89e32154dea91998114118e0e147ae67/statsmodels-0.14.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7a62f1fc9086e4b7ee789a6f66b3c0fc82dd8de1edda1522d30901a0aa45e42b", size = 10216574 },
+    { url = "https://files.pythonhosted.org/packages/ba/a5/2f09ab918296e534ea5d132e90efac51ae12ff15992d77539bbfca1158fa/statsmodels-0.14.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:46ac7ddefac0c9b7b607eed1d47d11e26fe92a1bc1f4d9af48aeed4e21e87981", size = 9912430 },
+    { url = "https://files.pythonhosted.org/packages/93/6a/b86f8c9b799dc93e5b4a3267eb809843e6328e34248a53496b96f50d732e/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a337b731aa365d09bb0eab6da81446c04fde6c31976b1d8e3d3a911f0f1e07b", size = 10444673 },
+    { url = "https://files.pythonhosted.org/packages/78/44/d72c634211797ed07dd8c63ced4ae11debd7a40b24ee80e79346a526194f/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:631bb52159117c5da42ba94bd94859276b68cab25dc4cac86475bc24671143bc", size = 10811248 },
+    { url = "https://files.pythonhosted.org/packages/35/64/df81426924fcc48a0402534efa96cde13275629ae52f123189d16c4b75ff/statsmodels-0.14.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3bb2e580d382545a65f298589809af29daeb15f9da2eb252af8f79693e618abc", size = 10946447 },
+    { url = "https://files.pythonhosted.org/packages/5c/f9/205130cceeda0eebd5a1a58c04e060c2f87a1d63cbbe37a9caa0fcb50c68/statsmodels-0.14.4-cp310-cp310-win_amd64.whl", hash = "sha256:9729642884147ee9db67b5a06a355890663d21f76ed608a56ac2ad98b94d201a", size = 9845796 },
+    { url = "https://files.pythonhosted.org/packages/48/88/326f5f689e69d9c47a68a22ffdd20a6ea6410b53918f9a8e63380dfc181c/statsmodels-0.14.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ed7e118e6e3e02d6723a079b8c97eaadeed943fa1f7f619f7148dfc7862670f", size = 10221032 },
+    { url = "https://files.pythonhosted.org/packages/07/0b/9a0818be42f6689ebdc7a2277ea984d6299f0809d0e0277128df4f7dc606/statsmodels-0.14.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5f537f7d000de4a1708c63400755152b862cd4926bb81a86568e347c19c364b", size = 9912219 },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/91c70a3b4a3e416f76ead61b04c87bc60080d634d7fa2ab893976bdd86fa/statsmodels-0.14.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa74aaa26eaa5012b0a01deeaa8a777595d0835d3d6c7175f2ac65435a7324d2", size = 10424053 },
+    { url = "https://files.pythonhosted.org/packages/9d/4f/a96e682f82b675e4a6f3de8ad990587d8b1fde500a630a2aabcaabee11d8/statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e332c2d9b806083d1797231280602340c5c913f90d4caa0213a6a54679ce9331", size = 10752529 },
+    { url = "https://files.pythonhosted.org/packages/4b/c6/47549345d32da1530a819a3699f6f34f9f70733a245eeb29f5e05e53f362/statsmodels-0.14.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9c8fa28dfd75753d9cf62769ba1fecd7e73a0be187f35cc6f54076f98aa3f3f", size = 10959003 },
+    { url = "https://files.pythonhosted.org/packages/4b/e4/f9e96896278308e17dfd4f60a84826c48117674c980234ee38f59ab28a12/statsmodels-0.14.4-cp311-cp311-win_amd64.whl", hash = "sha256:a6087ecb0714f7c59eb24c22781491e6f1cfffb660b4740e167625ca4f052056", size = 9853281 },
+    { url = "https://files.pythonhosted.org/packages/f5/99/654fd41a9024643ee70b239e5ebc987bf98ce9fc2693bd550bee58136564/statsmodels-0.14.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5221dba7424cf4f2561b22e9081de85f5bb871228581124a0d1b572708545199", size = 10220508 },
+    { url = "https://files.pythonhosted.org/packages/67/d8/ac30cf4cf97adaa48548be57e7cf02e894f31b45fd55bf9213358d9781c9/statsmodels-0.14.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:17672b30c6b98afe2b095591e32d1d66d4372f2651428e433f16a3667f19eabb", size = 9912317 },
+    { url = "https://files.pythonhosted.org/packages/e0/77/2440d551eaf27f9c1d3650e13b3821a35ad5b21d3a19f62fb302af9203e8/statsmodels-0.14.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab5e6312213b8cfb9dca93dd46a0f4dccb856541f91d3306227c3d92f7659245", size = 10301662 },
+    { url = "https://files.pythonhosted.org/packages/fa/e1/60a652f18996a40a7410aeb7eb476c18da8a39792c7effe67f06883e9852/statsmodels-0.14.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bbb150620b53133d6cd1c5d14c28a4f85701e6c781d9b689b53681effaa655f", size = 10741763 },
+    { url = "https://files.pythonhosted.org/packages/81/0c/2453eec3ac25e300847d9ed97f41156de145e507391ecb5ac989e111e525/statsmodels-0.14.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb695c2025d122a101c2aca66d2b78813c321b60d3a7c86bb8ec4467bb53b0f9", size = 10879534 },
+    { url = "https://files.pythonhosted.org/packages/59/9a/e466a1b887a1441141e52dbcc98152f013d85076576da6eed2357f2016ae/statsmodels-0.14.4-cp312-cp312-win_amd64.whl", hash = "sha256:7f7917a51766b4e074da283c507a25048ad29a18e527207883d73535e0dc6184", size = 9823866 },
+    { url = "https://files.pythonhosted.org/packages/31/f8/2662e6a101315ad336f75168fa9bac71f913ebcb92a6be84031d84a0f21f/statsmodels-0.14.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5a24f5d2c22852d807d2b42daf3a61740820b28d8381daaf59dcb7055bf1a79", size = 10186886 },
+    { url = "https://files.pythonhosted.org/packages/fa/c0/ee6e8ed35fc1ca9c7538c592f4974547bf72274bc98db1ae4a6e87481a83/statsmodels-0.14.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df4f7864606fa843d7e7c0e6af288f034a2160dba14e6ccc09020a3cf67cb092", size = 9880066 },
+    { url = "https://files.pythonhosted.org/packages/d1/97/3380ca6d8fd66cfb3d12941e472642f26e781a311c355a4e97aab2ed0216/statsmodels-0.14.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91341cbde9e8bea5fb419a76e09114e221567d03f34ca26e6d67ae2c27d8fe3c", size = 10283521 },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/55c5b5c5e5124a202ea3fe0bcdbdeceaf91b4ec6164b8434acb9dd97409c/statsmodels-0.14.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1322286a7bfdde2790bf72d29698a1b76c20b8423a55bdcd0d457969d0041f72", size = 10723228 },
+    { url = "https://files.pythonhosted.org/packages/4f/76/67747e49dc758daae06f33aad8247b718cd7d224f091d2cd552681215bb2/statsmodels-0.14.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e31b95ac603415887c9f0d344cb523889cf779bc52d68e27e2d23c358958fec7", size = 10859503 },
+    { url = "https://files.pythonhosted.org/packages/1d/eb/cb8b01f5edf8f135eb3d0553d159db113a35b2948d0e51eeb735e7ae09ea/statsmodels-0.14.4-cp313-cp313-win_amd64.whl", hash = "sha256:81030108d27aecc7995cac05aa280cf8c6025f6a6119894eef648997936c2dd0", size = 9817574 },
 ]
 
 [[package]]


### PR DESCRIPTION
Implement work by Hanjun and Flavio. 

Sensitivities are defined as the coefficients from a linear regression of the anomalies of `mrro ~ tas + pr` on a per basin basis.

### To do

- [x] Port the methodology as an analysis type in the ilamb3 system. Numbers are approximately correct based on CanESM5/Amazon figure provided by Hanjun.
- [x] Validate ilamb3 sensitivities with precise numbers form Hanjun.
- [ ] Add the MRB river basin regions to ILAMB-Data.
- [ ] Provide documentation for the ilamb3 readthedocs site.
- [x] Decide on the form of the reference data. Do we store the sensitivities as a dataset or do we have the users provide reference sources for `mrro`, `tas`, and `pr` and compute them on the fly?
- [x] Decide on a transformation of the sensitivities of the reference and comparison into a score as per the ilamb paradigm.
- [x] Create tests which cover all of the new methodology.

###  Ideas

- Create global maps of the sensitivities extended by their corresponding basins for the reference, comparison, and then bias.
- Scoring provides an opportunity to think about how to use uncertainty from both the reference *and* the comparison