### PR TITLE
CHANGE: None to configured global_region

### DIFF
--- a/ilamb3/analysis/area.py
+++ b/ilamb3/analysis/area.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+import ilamb3
 import ilamb3.compare as cmp
 import ilamb3.dataset as dset
 import ilamb3.plot as ilp
@@ -151,7 +152,7 @@ class area_analysis(ILAMBAnalysis):
             [
                 {
                     "source": "Reference",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": self.analysis_name,
                     "name": "Total Area",
                     "type": "scalar",
@@ -162,7 +163,7 @@ class area_analysis(ILAMBAnalysis):
             + [
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": self.analysis_name,
                     "name": f"{name} Area",
                     "type": "scalar",
@@ -177,7 +178,7 @@ class area_analysis(ILAMBAnalysis):
             + [
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": self.analysis_name,
                     "name": f"{name} Score",
                     "type": "score",
@@ -207,7 +208,7 @@ class area_analysis(ILAMBAnalysis):
             {
                 "name": "extent",
                 "title": self.req_variable.replace("_", " ").title(),
-                "region": None,
+                "region": ilamb3.conf["global_region"],
                 "source": source,
                 "axis": ilp.plot_map(
                     ds["extent"],
@@ -236,7 +237,7 @@ class area_analysis(ILAMBAnalysis):
             {
                 "name": "bias",
                 "title": "Bias",
-                "region": None,
+                "region": ilamb3.conf["global_region"],
                 "source": source,
                 "axis": ilp.plot_map(
                     ds["bias"],

--- a/ilamb3/analysis/nbp.py
+++ b/ilamb3/analysis/nbp.py
@@ -176,7 +176,7 @@ class nbp_analysis(ILAMBAnalysis):
             [
                 {
                     "source": "Reference",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "nbp",
                     "name": f"nbp({self.evaluation_year})",
                     "type": "scalar",
@@ -185,7 +185,7 @@ class nbp_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "nbp",
                     "name": f"nbp({self.evaluation_year})",
                     "type": "scalar",
@@ -194,7 +194,7 @@ class nbp_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "nbp",
                     "name": f"diff({self.evaluation_year})",
                     "type": "scalar",
@@ -203,7 +203,7 @@ class nbp_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "nbp",
                     "name": "Difference Score",
                     "type": "score",
@@ -212,7 +212,7 @@ class nbp_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "nbp",
                     "name": "Trajectory Score",
                     "type": "score",
@@ -236,7 +236,7 @@ class nbp_analysis(ILAMBAnalysis):
             {
                 "name": "accumulation",
                 "title": "nbp_accumulation",
-                "region": None,
+                "region": ilamb3.conf["global_region"],
                 "source": None,
                 "axis": plot_accumulated_nbp(
                     com, ref, vmin=float(uncert.min()), vmax=float(uncert.max())
@@ -248,7 +248,7 @@ class nbp_analysis(ILAMBAnalysis):
             {
                 "name": plot,
                 "title": "nbp",
-                "region": None,
+                "region": ilamb3.conf["global_region"],
                 "source": source,
                 "axis": (
                     ilplt.plot_curve(

--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -106,7 +106,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
             [
                 {
                     "source": "Reference",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Mean Temperature Sensitivity",
                     "type": "scalar",
@@ -115,7 +115,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Reference",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Mean Precipitation Sensitivity",
                     "type": "scalar",
@@ -124,7 +124,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Mean Temperature Sensitivity",
                     "type": "scalar",
@@ -133,7 +133,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Mean Precipitation Sensitivity",
                     "type": "scalar",
@@ -142,7 +142,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Bias Temperature Sensitivity",
                     "type": "scalar",
@@ -151,7 +151,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Bias Precipitation Sensitivity",
                     "type": "scalar",
@@ -160,7 +160,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Score Temperature Sensitivity",
                     "type": "score",
@@ -169,7 +169,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                 },
                 {
                     "source": "Comparison",
-                    "region": "None",
+                    "region": str(ilamb3.conf["global_region"]),
                     "analysis": "Runoff Sensitivity",
                     "name": "Score Precipitation Sensitivity",
                     "type": "score",
@@ -214,7 +214,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                     {
                         "name": var.replace("_", ""),
                         "title": title,
-                        "region": None,
+                        "region": ilamb3.conf["global_region"],
                         "source": model,
                         "axis": False,
                     }
@@ -225,7 +225,8 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                     return fig
                 else:
                     fig.savefig(
-                        self.output_path / f"{model}_None_{var.replace('_', '')}.png"
+                        self.output_path
+                        / f"{model}_{str(ilamb3.conf['global_region'])}_{var.replace('_', '')}.png"
                     )
                     plt.close()
 
@@ -236,7 +237,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
                     {
                         "name": str(basin.values),
                         "title": f"Basin plot for {str(basin.values)}",
-                        "region": None,
+                        "region": ilamb3.conf["global_region"],
                         "source": model,
                         "axis": False,
                     }
@@ -380,5 +381,8 @@ def _basin_plots(
     if output_path is None:
         return fig
     else:
-        fig.savefig(output_path / f"{model}_None_{str(basin.values)}.png")
+        fig.savefig(
+            output_path
+            / f"{model}_{str(ilamb3.conf['global_region'])}_{str(basin.values)}.png"
+        )
         plt.close()

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -94,8 +94,10 @@ def run(
     cache: bool = True,
     central_longitude: float = 0.0,
     title: str = "Benchmarking Results",
+    global_region: str | None = None,
 ):
     # by default, we run over the None region, that is, no regional reduction
+    ilamb3.conf.reset()
     if regions is None:
         regions = [None]
     else:
@@ -114,6 +116,7 @@ def run(
         plot_central_longitude=central_longitude,
         comparison_groupby=["source_id", "grid_label"],
         model_name_facets=["source_id"],
+        global_region=global_region,
     )
 
     # load local databases, need a better way

--- a/ilamb3/config.py
+++ b/ilamb3/config.py
@@ -25,6 +25,7 @@ defaults = {
     "run_mode": "interactive",  # for internal use
     "label_colors": {},
     "region_sources": [],
+    "global_region": None,  # which region label to we use for 'everything'
 }
 
 
@@ -79,6 +80,7 @@ class Config(dict):
         figure_dpi: int | None = None,
         debug_mode: bool | None = None,
         label_colors: dict[str, list[float]] | None = None,
+        global_region: str | None = None,
     ):
         """Change ilamb3 configuration options."""
         temp = copy.deepcopy(self)
@@ -113,6 +115,20 @@ class Config(dict):
         if label_colors is not None:
             assert isinstance(label_colors, dict)
             self["label_colors"].update(label_colors)
+        # This could cause a bug. If you set a region and then change your mind
+        # and want to change it back to None, you can't. But if you just always
+        # set it to None, you may erase the region someone has set and just
+        # didn't provide in the arguments.
+        if global_region is not None:
+            ilamb_regions = reg.Regions()
+            does_not_exist = (
+                set([global_region]) - set(ilamb_regions._regions) - set([None])
+            )
+            if does_not_exist:
+                raise ValueError(
+                    f"Cannot set {global_region=} because it is not registerd in our system: {list(ilamb_regions._regions)}"
+                )
+            self["global_region"] = global_region
         return self._unset(temp)
 
     def __getitem__(self, item):


### PR DESCRIPTION
When we would hardcode a None region, use instead a configured value 'global_region' so that it may be set and avoid a display problem when both None and global data is part of the run