### PR TITLE
CHANGE: cli improvements

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -165,8 +165,8 @@ The benchmark dashboard is designed to assist you in discovering patterns in the
 
 In order to solidify these basic `ilamb3` concepts, we recommend that you attempt the following expansions on your own:
 
-1. **Add another model:** This consists of creating another (or expanding the current) CSV file. To keep downloads small, you might choose to add `UKESM1-0-LL` because it is also relatively coarse like CanESM5. If you create a second CSV file, when running `ilamb3`, you can just add it to the `--model-db` option separated by a comma. We will concatenate these files together internally:
+1. **Add another model:** This consists of creating another (or expanding the current) CSV file. To keep downloads small, you might choose to add `UKESM1-0-LL` because it is also relatively coarse like CanESM5. If you create a second CSV file, when running `ilamb3`, you can just add another `--model-db` option. We will concatenate these files together internally:
 ```{code} bash
-ilamb run basic_step1.yaml --model-db CanESM5.csv,UKESM1-0-LL.csv
+ilamb run basic_step1.yaml --model-db CanESM5.csv --model-db UKESM1-0-LL.csv
 ```
 2. **Add another benchmark:** Locate the `ilamb3` registry key for the `Fluxnet-2015` `gpp` data from the [datasets](datasets) page. Add another benchmark block to `my_benchmark_study.yaml` which is also under the `Gross Primary Productivity` heading. Essentially, you need to duplicate the `WECANN-1-0` block and then replace the WECANN-specific information with Fluxnet2015-specific information.

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -1,9 +1,15 @@
-import os
+from collections.abc import MutableMapping
 from pathlib import Path
+from typing import Annotated
 
 import pandas as pd
 import pooch
 import typer
+
+import ilamb3
+import ilamb3.meta as meta
+import ilamb3.regions as ilr
+from ilamb3.run import parse_benchmark_setup, run_study
 
 try:
     from ilamb3.parallel import run_study_parallel
@@ -12,102 +18,132 @@ try:
 except ImportError:
     HAS_MPI4PY = False
 
-import ilamb3
-import ilamb3.meta as meta
-import ilamb3.regions as ilr
-from ilamb3.run import parse_benchmark_setup, run_study
 
 app = typer.Typer(name="ilamb", no_args_is_help=True)
 
 
-def _dataframe_reference(
-    root: Path = pooch.os_cache("ilamb3"),
-    cache_file: Path = Path("df_reference.csv"),
-) -> pd.DataFrame:
-    if cache_file.exists():
-        df = pd.read_csv(cache_file)
-        df = df.set_index("key")
-        return df
-    if "ILAMB_ROOT" in os.environ:
-        root = Path(os.environ["ILAMB_ROOT"])
-    df = []
-    for dirpath, _, files in root.walk():
-        for fname in files:
-            if not fname.endswith(".nc"):
-                continue
-            path = dirpath / fname
-            df.append(
-                {
-                    "key": str(Path(*path.relative_to(root).parts[1:])),
-                    "path": str(path.absolute()),
-                }
+def _flatten_dict_gen(d, parent_key, sep):
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, MutableMapping):
+            yield from flatten_dict(v, new_key, sep=sep).items()
+        else:
+            yield new_key, v
+
+
+def flatten_dict(d: MutableMapping, parent_key: str = "", sep: str = "."):
+    """
+    Flatten a nested dictionary by composing keys with a separator.
+    """
+    return dict(_flatten_dict_gen(d, parent_key, sep))
+
+
+def parse_registry_keys(config: Path) -> list[str]:
+    """
+    Return all keys from the configure file that are part of a ilamb registry.
+    """
+    setup = parse_benchmark_setup(config)
+    keys = list(
+        set([val for _, val in flatten_dict(setup).items()]).intersection(
+            set(
+                ilamb3.ilamb_catalog().registry_files
+                + ilamb3.iomb_catalog().registry_files
+                + ilamb3.ilamb3_catalog().registry_files
             )
-    df = pd.DataFrame(df)
-    df.to_csv(cache_file, index=False)
+        )
+    )
+    return keys
+
+
+def get_local_path(key: str, catalogs: list[pooch.Pooch]) -> Path | None:
+    """
+    Return the local path of a file in our registry, if the file exists.
+    """
+    for cat in catalogs:
+        if key in cat.registry_files:
+            local = cat.abspath / key
+            if local.is_file():
+                return local
+            else:
+                return None
+    return None
+
+
+def fetch_key(key: str, catalogs: list[pooch.Pooch]) -> None:
+    """
+    Fetch from a list of pooch catalogs.
+    """
+    for cat in catalogs:
+        if key in cat.registry_files:
+            cat.fetch(key)
+
+
+def form_reference_dataframe(keys: list[str]) -> pd.DataFrame:
+    """
+    Create a dataframe for the keys found in ilamb catalogs.
+    """
+    catalogs = [ilamb3.ilamb_catalog(), ilamb3.iomb_catalog(), ilamb3.ilamb3_catalog()]
+    df = pd.DataFrame(
+        [{"key": key, "path": get_local_path(key, catalogs)} for key in keys]
+    )
     df = df.set_index("key")
     return df
 
 
-def _dataframe_cmip(
-    root: Path | None = None,
-    cache_file: Path = Path("df_cmip.csv"),
-) -> pd.DataFrame:
-    if cache_file.exists():
-        df = pd.read_csv(cache_file)
-        return df
-    if root is None:
-        if "ESGF_ROOT" in os.environ:
-            root = Path(os.environ["ESGF_ROOT"])
-        else:
-            root = Path.home() / ".esgf"
-    df = []
-    for dirpath, _, files in root.walk():
-        for fname in files:
-            if not fname.endswith(".nc"):
-                continue
-            path = str((dirpath / fname).absolute())
-            df.append(
-                {
-                    "mip_era": path.split("/")[-11],
-                    "activity_id": path.split("/")[-10],
-                    "institution_id": path.split("/")[-9],
-                    "source_id": path.split("/")[-8],
-                    "experiment_id": path.split("/")[-7],
-                    "member_id": path.split("/")[-6],
-                    "table_id": path.split("/")[-5],
-                    "variable_id": path.split("/")[-4],
-                    "grid_label": path.split("/")[-3],
-                    "path": path,
-                }
-            )
-    df = pd.DataFrame(df)
-    df.to_csv(cache_file, index=False)
-    return df
-
-
-@app.command(help="Run a benchmarking analysis")
+@app.command(help="Run a benchmarking analysis.")
 def run(
-    config: Path,
-    regions: str | None = None,
-    region_sources: list[str] | None = None,
-    df_comparison: list[Path] | None = None,
-    output_path: Path = Path("_build"),
-    cache: bool = True,
-    central_longitude: float = 0.0,
-    title: str = "Benchmarking Results",
-    global_region: str | None = None,
+    config: Annotated[Path, typer.Argument(help="The benchmark study yaml file.")],
+    model_db: Annotated[
+        list[Path],
+        typer.Option(
+            help="The model database file(s) in CSV format. Use the option multiple times to specify multiple files."
+        ),
+    ],
+    regions: Annotated[
+        str | None,
+        typer.Option(
+            help="The region label over which the analysis is run. Use the option multiple times to specify multiple regions."
+        ),
+    ] = None,
+    region_source: Annotated[
+        list[Path] | None,
+        typer.Option(
+            help="The file (text or netCDF) which provides more regions over which the analysis may be run. Use the option multiple times to specify multiple files."
+        ),
+    ] = None,
+    output_path: Annotated[
+        Path,
+        typer.Option(
+            help="The path in which ilamb3 will write the benchmark study output."
+        ),
+    ] = Path("_build"),
+    cache: Annotated[
+        bool,
+        typer.Option(help="Enable to use cached intermediate files in the analysis."),
+    ] = True,
+    central_longitude: Annotated[
+        float,
+        typer.Option(
+            help="The longitude around which the global map plots will be centered."
+        ),
+    ] = 0.0,
+    title: Annotated[
+        str,
+        typer.Option(
+            help="A title to be displayed on the benchmarking study results page."
+        ),
+    ] = "Benchmarking Results",
+    main_region: Annotated[
+        str | None,
+        typer.Option(help="A region label that will be displayed first in the output."),
+    ] = None,
 ):
-    # by default, we run over the None region, that is, no regional reduction
     ilamb3.conf.reset()
-    if regions is None:
-        regions = [None]
-    else:
-        regions = [None if r.lower() == "none" else r for r in regions.split(",")]
-    if region_sources is not None:
+    if region_source is not None:
         cat = ilamb3.ilamb_catalog()
-        for source in region_sources:
+        for source in region_source:
             ilr.Regions().add_netcdf(cat.fetch(source))
-        ilamb3.conf["region_sources"] = region_sources
+        ilamb3.conf["region_sources"] = region_source
 
     # set options
     ilamb3.conf.set(
@@ -117,16 +153,17 @@ def run(
         plot_central_longitude=central_longitude,
         comparison_groupby=["source_id", "grid_label"],
         model_name_facets=["source_id"],
-        global_region=global_region,
+        global_region=main_region,
     )
 
-    # load local databases, need a better way
-    df_ref = _dataframe_reference()
-    if df_comparison is None:
-        df_com = _dataframe_cmip()
-    else:
-        df_comparison = [Path(f) for f in str(df_comparison[0]).split(",")]
-        df_com = pd.concat([pd.read_csv(f) for f in df_comparison])
+    # load local databases
+    df_ref = form_reference_dataframe(parse_registry_keys(config))
+    if df_ref["path"].isnull().any():
+        config = str(config)
+        raise ValueError(
+            f"Some of the reference data keys you specify in {config=} is not locally available: {list(df_ref[df_ref['path'].isnull()].index)}.\nRun `ilamb fetch {config}` to download files locally."
+        )
+    df_com = pd.concat([pd.read_csv(f) for f in model_db])
 
     # execute
     if HAS_MPI4PY:
@@ -153,49 +190,33 @@ def run(
         pass
 
 
-@app.command(help="Fetch reference data")
-def fetch(config: Path):
-    def _extract_sources(current: dict):
-        """Recursively extract the source keys."""
-        sources = []
-        for _, val in current.items():
-            if not isinstance(val, dict):
-                continue
-            if "sources" in val:
-                sources += [key for _, key in val["sources"].items()]
-            elif "relationships" in val:
-                sources += [key for _, key in val["relationships"].items()]
-            else:
-                sources += _extract_sources(val)
-        return sources
-
-    setup = parse_benchmark_setup(config)
-    sources = list(set(_extract_sources(setup)))
-    registries = [
-        ilamb3.ilamb_catalog(),
-        ilamb3.iomb_catalog(),
-        ilamb3.ilamb3_catalog(),
-    ]
-    for source in sources:
-        found = False
-        for reg in registries:
-            if source in reg.registry_files:
-                reg.fetch(source)
-                found = True
-        if not found:
-            raise ValueError(f"Could not find '{source}' in the data registries.")
-
-    # Messy, find a way to get rid of this idea
-    Path("df_reference.csv").unlink(missing_ok=True)
+@app.command(help="Fetch reference data if part of an ILAMB catalog.")
+def fetch(
+    config: Annotated[Path, typer.Argument(help="The benchmark study yaml file.")],
+):
+    catalogs = [ilamb3.ilamb_catalog(), ilamb3.iomb_catalog(), ilamb3.ilamb3_catalog()]
+    df = form_reference_dataframe(parse_registry_keys(config))
+    df = df[df["path"].isnull()]
+    for key in df.index:
+        fetch_key(key, catalogs)
 
 
 @app.command(help="What went wrong in the run?")
-def debug(output_path: Path):
+def debug(
+    output_path: Annotated[
+        Path,
+        typer.Argument(
+            help="The path in which ilamb3 will write the benchmark study output."
+        ),
+    ],
+):
     for root, _, files in output_path.walk():
         logs_no_csvs = [
             f
             for f in files
-            if f.endswith(".log") and f"{(root / f).stem}.csv" not in files
+            if f.endswith(".log")
+            and f"{(root / f).stem}.csv" not in files
+            and (root / f).stat().st_size > 0
         ]
         if logs_no_csvs:
             print(f"\n{root}")

--- a/ilamb3/tests/test_cli.py
+++ b/ilamb3/tests/test_cli.py
@@ -1,0 +1,45 @@
+import tempfile
+from pathlib import Path
+
+import yaml
+from pytest import fixture
+
+import ilamb3
+import ilamb3.cli as cli
+
+
+@fixture
+def ilamb_catalogs():
+    return [ilamb3.ilamb3_catalog(), ilamb3.ilamb_catalog()]
+
+
+@fixture
+def ilamb_data_key():
+    cat = ilamb3.ilamb3_catalog()
+    some_key = cat.registry_files[0]
+    return some_key
+
+
+def test_flatten_dict():
+    nested_dict = {"level0": {"level1": {"level2": "hi"}}, "stuff": "cool"}
+    flat_dict = cli.flatten_dict(nested_dict)
+    assert len(flat_dict) == 2
+
+
+def test_parse_registry_keys(ilamb_data_key):
+    out = {
+        "Heading1": {
+            "Another1": {
+                "Something": {
+                    "sources": {"fake": ilamb_data_key},
+                    "variable_cmap": "Greens",
+                }
+            }
+        }
+    }
+    config_file = Path(tempfile.gettempdir()) / "junk.yaml"
+    with open(str(config_file), "w") as f:
+        f.write(yaml.dump(out))
+    keys = cli.parse_registry_keys(config_file)
+    assert len(keys) == 1
+    assert keys[0] == ilamb_data_key

--- a/ilamb3/tests/test_cli.py
+++ b/ilamb3/tests/test_cli.py
@@ -1,6 +1,8 @@
+import os
 import tempfile
 from pathlib import Path
 
+import pandas as pd
 import yaml
 from pytest import fixture
 
@@ -43,3 +45,23 @@ def test_parse_registry_keys(ilamb_data_key):
     keys = cli.parse_registry_keys(config_file)
     assert len(keys) == 1
     assert keys[0] == ilamb_data_key
+
+
+def test_get_local_path():
+    os.environ["ILAMB_ROOT"] = tempfile.TemporaryDirectory().name
+    catalogs = [ilamb3.ilamb_catalog()]
+    local_path = cli.get_local_path("test/Site/tas.nc", catalogs)
+    assert local_path is None
+    cli.fetch_key("test/Site/tas.nc", catalogs)
+    local_path = cli.get_local_path("test/Site/tas.nc", catalogs)
+    assert local_path is not None
+    assert local_path.is_file()
+
+
+def test_form_reference_dataframe():
+    os.environ["ILAMB_ROOT"] = tempfile.TemporaryDirectory().name
+    catalogs = [ilamb3.ilamb_catalog()]
+    cli.fetch_key("test/Site/tas.nc", catalogs)
+    df = cli.form_reference_dataframe(["test/Site/tas.nc"])
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 1


### PR DESCRIPTION
- Commands and options now have help strings
- `--df-comparison` is now `--model-db`
- Fetch will now harvest any key found anywhere in the configure file
- `df_reference.csv` is no longer used
- Comma-delimited options are not longer supported. This is because `typer` is not meant to work this way. 