### PR TITLE
ADD: support for distinguishing time frequency

### DIFF
--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -44,7 +44,9 @@ def parse_registry_keys(config: Path) -> list[str]:
     """
     setup = parse_benchmark_setup(config)
     keys = list(
-        set([val for _, val in flatten_dict(setup).items()]).intersection(
+        set(
+            [val for _, val in flatten_dict(setup).items() if isinstance(val, str)]
+        ).intersection(
             set(
                 ilamb3.ilamb_catalog().registry_files
                 + ilamb3.iomb_catalog().registry_files

--- a/ilamb3/dataset.py
+++ b/ilamb3/dataset.py
@@ -12,6 +12,8 @@ from scipy.interpolate import NearestNDInterpolator
 import ilamb3.regions as ilreg
 from ilamb3.exceptions import NoSiteDimension, NoUncertainty
 
+CMIP_TIME_FREQUENCY = {"3hr": 0.125, "6hr": 0.25, "day": 1.0, "mon": 30.0, "yr": 365.0}
+
 
 def _get_bnds_dims(dset: xr.Dataset | xr.DataArray) -> list[str]:
     """ """
@@ -1149,6 +1151,17 @@ def get_mean_time_frequency(ds: xr.Dataset) -> float:
     """
     tm = compute_time_measures(ds)
     return float(tm.mean())
+
+
+def get_frequency_label(ds: xr.Dataset) -> str | None:
+    """
+    Return the CMIP time frequency label of the dataset.
+    """
+    if not is_temporal(ds):
+        return "fx"
+    dt = get_mean_time_frequency(ds)
+    distance = {key: np.abs(value - dt) for key, value in CMIP_TIME_FREQUENCY.items()}
+    return min(distance, key=distance.get)
 
 
 def compute_monthly_mean(ds: xr.Dataset) -> xr.Dataset:

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -273,3 +273,20 @@ def load_comparison_data(
         )
     ds_com = dset.cmip_cell_measures(ds_com, variable_id)
     return ds_com
+
+
+def add_frequency_column(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add a time frequency column if one does not exist using CMIP labels.
+    """
+
+    def _add_frequency(row) -> str:
+        ds = xr.open_dataset(row["path"])
+        if row["frequency"] in list(dset.CMIP_TIME_FREQUENCY.keys()) + ["fx"]:
+            return row["frequency"]
+        return dset.get_frequency_label(ds)
+
+    if "frequency" not in df.columns:
+        df["frequency"] = None
+    df["frequency"] = df.apply(_add_frequency, axis=1)
+    return df

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -101,7 +101,7 @@ def _pre_merge(ds: xr.Dataset, keep: list[str]) -> xr.Dataset:
     return ds
 
 
-def _lookup(df: xr.Dataset, key: str) -> list[str]:
+def _lookup(df: pd.DataFrame, key: str) -> list[str]:
     """
     Lookup the key in the dataframe.
 

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -281,9 +281,9 @@ def add_frequency_column(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     def _add_frequency(row) -> str:
-        ds = xr.open_dataset(row["path"])
         if row["frequency"] in list(dset.CMIP_TIME_FREQUENCY.keys()) + ["fx"]:
             return row["frequency"]
+        ds = xr.open_dataset(row["path"])
         return dset.get_frequency_label(ds)
 
     if "frequency" not in df.columns:
@@ -295,6 +295,9 @@ def add_frequency_column(df: pd.DataFrame) -> pd.DataFrame:
 def match_frequency(df: pd.DataFrame, target_frequency: str) -> pd.DataFrame:
     """
     Remove rows of the dataframe that do not match the target frequency.
+
+    This function assumes that the input dataframe has already been reduced to a
+    single model's output.
 
     Note
     ----

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -290,3 +290,33 @@ def add_frequency_column(df: pd.DataFrame) -> pd.DataFrame:
         df["frequency"] = None
     df["frequency"] = df.apply(_add_frequency, axis=1)
     return df
+
+
+def match_frequency(df: pd.DataFrame, target_frequency: str) -> pd.DataFrame:
+    """
+    Remove rows of the dataframe that do not match the target frequency.
+
+    Note
+    ----
+    This will not completely remove a variable from the dataframe. It only
+    removes additional frequencies so that xr.open_mfdataset does not fail. If
+    your dataframe has `mon` and `6hr` and you ask for `day`, you will get the
+    `6hr` data.
+    """
+    if "frequency" not in df.columns:
+        df = add_frequency_column(df)
+    drop_indices = []
+    for _, grp in df.groupby("variable_id"):
+        freqs = pd.unique(grp["frequency"])
+        # If only 1 time frequency, then we go with that
+        if len(freqs) == 1:
+            continue
+        # Otherwise, find the closest frequency we have and drop others
+        distance = {
+            key: np.abs(value - dset.CMIP_TIME_FREQUENCY[target_frequency])
+            for key, value in dset.CMIP_TIME_FREQUENCY.items()
+        }
+        closest_label = min(distance, key=distance.get)
+        drop_indices += grp[grp["frequency"] != closest_label].index.to_list()
+    df = df.drop(drop_indices)
+    return df

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -60,6 +60,9 @@ def _perform_work_phase1(work, reference_data, output_path):
     if len(grp) < 1:
         return
 
+    # Add a 'frequency' column if one does not exist
+    grp = ill.add_frequency_column(grp)
+
     # try to run the comparison
     try:
         ref = ill.load_reference_data(
@@ -69,6 +72,15 @@ def _perform_work_phase1(work, reference_data, output_path):
             setup["relationships"] if "relationships" in setup else {},
             transforms=transforms,
         )
+    except Exception:
+        with open(log_file, "a") as log:
+            log.write(
+                f"ILAMB analysis '{block_name}' failed for '{source_name}' when loading reference data on {process_name} ({rank}/{size})\n"
+            )
+            log.write(format_exc())
+        return
+
+    try:
         com = ill.load_comparison_data(
             grp,
             variable,

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -52,8 +52,10 @@ def _perform_work_phase1(work, reference_data, output_path):
             run.find_related_variables(
                 analyses, transforms, setup.get("alternate_vars", [])
             )
+            + ["areacella", "sftlf", "areacello", "sftof"]
         )
     ]
+
     # if we didn't find anything, just leave
     if len(grp) < 1:
         return

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -12,6 +12,7 @@ from mpi4py.futures import MPIPoolExecutor, get_comm_workers
 from tqdm import tqdm
 
 import ilamb3
+import ilamb3.dataset as ild
 import ilamb3.load as ill
 import ilamb3.regions as ilr
 import ilamb3.run as run
@@ -79,6 +80,10 @@ def _perform_work_phase1(work, reference_data, output_path):
             )
             log.write(format_exc())
         return
+
+    # Match the reference time frequency if possible
+    cmip_time_lbl = ild.get_frequency_label(ref[variable])
+    grp = ill.match_frequency(grp, cmip_time_lbl)
 
     try:
         com = ill.load_comparison_data(

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -1,3 +1,7 @@
+"""
+Functions which implement the parallel algorithm for running ILAMB.
+"""
+
 import itertools
 import shutil
 from functools import partial
@@ -19,7 +23,14 @@ import ilamb3.run as run
 
 
 def _perform_work_phase1(work, reference_data, output_path):
-    """ """
+    """
+    Run the first phase of ILAMB where analyses are run and intermediate netCDF
+    and CSV files are generated.
+
+    Note
+    ----
+    This function is called from a MPIThreadPool to achieve parallelism.
+    """
     # unpack work
     setup, grp = work
     block_name = setup["path"].split("/")[-1]
@@ -64,7 +75,7 @@ def _perform_work_phase1(work, reference_data, output_path):
     # Add a 'frequency' column if one does not exist
     grp = ill.add_frequency_column(grp)
 
-    # try to run the comparison
+    # load reference data
     try:
         ref = ill.load_reference_data(
             reference_data,
@@ -81,17 +92,28 @@ def _perform_work_phase1(work, reference_data, output_path):
             log.write(format_exc())
         return
 
-    # Match the reference time frequency if possible
-    cmip_time_lbl = ild.get_frequency_label(ref[variable])
-    grp = ill.match_frequency(grp, cmip_time_lbl)
-
+    # load comparison data
     try:
+        # Match the reference time frequency if possible
+        cmip_time_lbl = ild.get_frequency_label(ref[variable])
+        grp = ill.match_frequency(grp, cmip_time_lbl)
+
         com = ill.load_comparison_data(
             grp,
             variable,
             alternate_vars=setup.get("alternate_vars", []),
             transforms=transforms,
         )
+    except Exception:
+        with open(log_file, "a") as log:
+            log.write(
+                f"ILAMB analysis '{block_name}' failed for '{source_name}' when loading comparison data on {process_name} ({rank}/{size})\n"
+            )
+            log.write(format_exc())
+        return
+
+    # run the analyses
+    try:
         dfs, ds_ref, ds_com = run.run_analyses(ref, com, analyses)
         dfs["source"] = dfs["source"].str.replace("Comparison", source_name)
 
@@ -125,6 +147,14 @@ def _perform_work_phase1(work, reference_data, output_path):
 
 
 def _perform_work_phase2(setup, output_path):
+    """
+    Run the first phase of ILAMB where analyses are run and intermediate netCDF
+    and CSV files are generated.
+
+    Note
+    ----
+    This function is called from a MPIThreadPool to achieve parallelism.
+    """
     # unpack work
     block_name = setup["path"].replace("/", " | ")
     local_path = output_path / setup["path"]

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -281,6 +281,9 @@ def run_single_block(
         )
     ]
 
+    # Add a 'frequency' column if one does not exist
+    comparison_data = ill.add_frequency_column(comparison_data)
+
     # Phase I: loop over each model in the group and run an analysis function
     df_all = []
     ds_com = {}
@@ -309,8 +312,8 @@ def run_single_block(
             except Exception:
                 pass
 
+        # Load the reference data
         try:
-            # Load data and run comparison
             ref = ill.load_reference_data(
                 reference_data,
                 variable,
@@ -318,6 +321,16 @@ def run_single_block(
                 setup["relationships"] if "relationships" in setup else {},
                 transforms=transforms,
             )
+        except Exception:  # pragma: no cover
+            logger.exception(
+                f"ILAMB analysis '{block_name}' failed for '{source_name}' when loading the reference data."
+            )
+            logger.remove(log_id)
+            continue
+
+        # Now that we have the reference data,
+
+        try:
             com = ill.load_comparison_data(
                 grp,
                 variable,

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -237,21 +237,6 @@ def registry_to_dataframe(registry: pooch.Pooch) -> pd.DataFrame:
     return df.set_index("key")
 
 
-def remove_irrelevant_variables(df: pd.DataFrame, **setup: Any) -> pd.DataFrame:
-    """
-    Remove unused variables from the dataframe.
-    """
-    reduce = df[
-        df["variable_id"].isin(
-            list(setup["sources"].keys())
-            + list(setup.get("relationships", {}).keys())
-            + setup.get("alternate_vars", [])
-            + setup.get("related_vars", [])
-        )
-    ]
-    return reduce
-
-
 def _load_local_assets(
     csv_file: Path, ref_file: Path, com_file: Path
 ) -> tuple[pd.DataFrame, xr.Dataset, xr.Dataset]:

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 import ilamb3
 import ilamb3.analysis as anl
+import ilamb3.dataset as ild
 import ilamb3.load as ill
 import ilamb3.plot as ilp
 import ilamb3.regions as ilr
@@ -328,8 +329,11 @@ def run_single_block(
             logger.remove(log_id)
             continue
 
-        # Now that we have the reference data,
+        # Match the reference time frequency if possible
+        cmip_time_lbl = ild.get_frequency_label(ref)
+        grp = ill.match_frequency(grp, cmip_time_lbl)
 
+        #
         try:
             com = ill.load_comparison_data(
                 grp,

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -1,4 +1,6 @@
-"""Functions for rendering ilamb3 output."""
+"""
+Functions which implement the serial algorithm for running ILAMB.
+"""
 
 import importlib
 import re

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -5,6 +5,7 @@ import re
 import shutil
 from itertools import chain
 from pathlib import Path
+from traceback import format_exc
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -188,6 +189,18 @@ def augment_setup_with_options(
 ) -> dict[str, Any]:
     """
     Augment the configure block with global ilamb3 options.
+
+    Parameters
+    ----------
+    setup: dict
+        A dictionary of keywords parsed from the configure files.
+    reference_data: pd.DataFrame
+        The dataframe containing the reference keys and paths.
+
+    Returns
+    -------
+    dict[str,Any]
+        The setup block augmented with global options.
     """
     # Augment options with things in the global options
     if "regions" not in setup:
@@ -241,6 +254,9 @@ def registry_to_dataframe(registry: pooch.Pooch) -> pd.DataFrame:
 def _load_local_assets(
     csv_file: Path, ref_file: Path, com_file: Path
 ) -> tuple[pd.DataFrame, xr.Dataset, xr.Dataset]:
+    """
+    Load the model intermediate assets if present.
+    """
     if not (csv_file.is_file() and ref_file.is_file() and com_file.is_file()):
         raise ValueError()
     df = pd.read_csv(str(csv_file))
@@ -256,13 +272,23 @@ def run_single_block(
     comparison_data: pd.DataFrame,
     output_path: Path,
     **setup: Any,
-):
+) -> None:
     """
     Run a configuration block.
 
     Parameters
     ----------
-
+    block_name: str
+        The name of the block to be run, used in error reporting.
+    reference_data: pd.DataFrame
+        The dataframe containing the reference keys and paths.
+    comparison_data: pd.DataFrame
+        The dataframe containing the comparison description columns and paths to
+        the local files.
+    output_path: Path
+        The path to save all benchmark data for this block.
+    setup: Any
+        The keyword arguments of the benchmark setup block.
     """
     # Initialize
     if reference_data.index.name != "key":
@@ -285,7 +311,7 @@ def run_single_block(
     # Add a 'frequency' column if one does not exist
     comparison_data = ill.add_frequency_column(comparison_data)
 
-    # Phase I: loop over each model in the group and run an analysis function
+    # Phase I: loop over each model in the group and run all analysis functions
     df_all = []
     ds_com = {}
     ds_ref = None
@@ -329,18 +355,26 @@ def run_single_block(
             logger.remove(log_id)
             continue
 
-        # Match the reference time frequency if possible
-        cmip_time_lbl = ild.get_frequency_label(ref)
-        grp = ill.match_frequency(grp, cmip_time_lbl)
-
-        #
+        # Load the comparison data
         try:
+            # Match the reference time frequency if possible
+            cmip_time_lbl = ild.get_frequency_label(ref)
+            grp = ill.match_frequency(grp, cmip_time_lbl)
             com = ill.load_comparison_data(
                 grp,
                 variable,
                 alternate_vars=setup.get("alternate_vars", []),
                 transforms=transforms,
             )
+        except Exception:  # pragma: no cover
+            logger.exception(
+                f"ILAMB analysis '{block_name}' failed for '{source_name}' when loading the comparison data."
+            )
+            logger.remove(log_id)
+            continue
+
+        # Run the analyses
+        try:
             dfs, ds_ref, ds_com[source_name] = run_analyses(ref, com, analyses)
             ds_ref = ds_ref.assign_attrs(ref.attrs)  # Retain global attrs
             dfs["source"] = dfs["source"].str.replace("Comparison", source_name)
@@ -384,7 +418,7 @@ def run_single_block(
     log_file = output_path / "post.log"
     log_id = logger.add(log_file, backtrace=True, diagnose=True)
 
-    # Phase 2: get plots and combine scalars and save
+    # Phase II: get plots and combine scalars and save
     try:
         plt.rcParams.update({"figure.max_open_warning": 0})
         df = pd.concat(df_all).drop_duplicates(
@@ -437,7 +471,7 @@ def run_analyses(
     dfs = []
     ds_refs = []
     ds_coms = []
-    for aname, a in analyses.items():
+    for _, a in analyses.items():
         try:
             df, ds_ref, ds_com = a(ref, com)
         except AnalysisNotAppropriate:
@@ -545,7 +579,7 @@ def generate_html_page(
     Returns
     -------
     str
-        The html page.
+        The benchmark data dashboard as html.
     """
     ilamb_regions = ilr.Regions()
     # Setup template analyses and plots
@@ -602,6 +636,9 @@ def generate_html_page(
 
 
 def _flatten_dict(d: dict, parent_key: str = "", sep: str = "/") -> dict:
+    """
+    Return the setup dictionary de-nested with the paths expanded.
+    """
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
@@ -613,14 +650,18 @@ def _flatten_dict(d: dict, parent_key: str = "", sep: str = "/") -> dict:
 
 
 def _clean_pathname(filename: str) -> str:
-    """Removes characters we do not want in our paths."""
+    """
+    Removes characters we do not want in our paths.
+    """
     invalid_chars = r'[\\/:*?"<>|\s]'
     cleaned_filename = re.sub(invalid_chars, "", filename)
     return cleaned_filename
 
 
 def _is_leaf(current: dict) -> bool:
-    """Is the current item in the nested dictionary a leaf?"""
+    """
+    Is the current item in the nested dictionary a leaf?
+    """
     if not isinstance(current, dict):
         return False
     if "sources" in current:
@@ -629,7 +670,9 @@ def _is_leaf(current: dict) -> bool:
 
 
 def _add_path(current: dict, path: Path | None = None) -> dict:
-    """Recursively add the nested dictionary headings as a `path` in the leaves."""
+    """
+    Recursively add the nested dictionary headings as a `path` in the leaves.
+    """
     path = Path() if path is None else path
     for key, val in current.items():
         if not isinstance(val, dict):
@@ -643,7 +686,9 @@ def _add_path(current: dict, path: Path | None = None) -> dict:
 
 
 def _to_leaf_list(current: dict, leaf_list: list | None = None) -> list:
-    """Recursively flatten the nested dictionary only returning the leaves."""
+    """
+    Recursively flatten the nested dictionary only returning the leaves.
+    """
     leaf_list = [] if leaf_list is None else leaf_list
     for _, val in current.items():
         if not isinstance(val, dict):
@@ -656,7 +701,9 @@ def _to_leaf_list(current: dict, leaf_list: list | None = None) -> list:
 
 
 def _create_paths(current: dict, root: Path):
-    """Recursively ensure paths in the leaves are created."""
+    """
+    Recursively ensure paths in the leaves are created.
+    """
     for _, val in current.items():
         if not isinstance(val, dict):
             continue
@@ -668,7 +715,9 @@ def _create_paths(current: dict, root: Path):
 
 
 def parse_benchmark_setup(yaml_file: str | Path) -> dict:
-    """Parse the file which is analagous to the old configure file."""
+    """
+    Parse the benchmark setup file.
+    """
     yaml_file = Path(yaml_file)
     with open(yaml_file) as fin:
         analyses = yaml.safe_load(fin)
@@ -701,7 +750,22 @@ def run_study(
     df_datasets: pd.DataFrame,
     ref_datasets: pd.DataFrame | None = None,
     output_path: str | Path = "_build",
-):
+) -> None:
+    """
+    Run the benchmark study specified by the setup file using the serial
+    algorithm.
+
+    Parameters
+    ----------
+    study_setup: str
+        The path to the benchmark setup yaml file.
+    df_datasets: pd.DataFrame
+        The comparison dataset DataFrame.
+    ref_datasets: pd.DataFrame
+        The reference datasets DataFrame, optional.
+    output_path: str or Path
+        The path in which the study output will be saved.
+    """
     ilamb3.conf["run_mode"] = "batch"
     output_path = Path(output_path)
     # Some yaml text that would get parsed like a dictionary.
@@ -715,12 +779,7 @@ def run_study(
         raise ValueError("Unsupported registry.")
     set_model_colors(df_datasets)
 
-    # The yaml analysis setup can be as structured as the user needs. We are no longer
-    # limited to the `h1` and `h2` headers from ILAMB 2.x. We will detect leaf nodes by
-    # the presence of a `sources` dictionary.
     analyses = _add_path(analyses)
-
-    # Various traversal actions
     _create_paths(analyses, output_path)
 
     # Save configure
@@ -747,3 +806,4 @@ def run_study(
             )
         except Exception as exc:
             logger.debug(f"Uncaught error when running {block_name}: {exc}")
+            logger.debug(format_exc())

--- a/ilamb3/tests/test_dataset.py
+++ b/ilamb3/tests/test_dataset.py
@@ -211,3 +211,9 @@ def test_cell_measures():
     ds["lat"].attrs["bounds"] = "lat_bnds"
     ds["lon"].attrs["bounds"] = "lon_bnds"
     assert np.allclose(dset.compute_cell_measures(ds).mean(), 2.83369151e13)
+
+
+def test_get_frequency_label():
+    ds = generate_test_dset()
+    lbl = dset.get_frequency_label(ds)
+    assert lbl == "mon"

--- a/ilamb3/tests/test_load.py
+++ b/ilamb3/tests/test_load.py
@@ -1,0 +1,27 @@
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import ilamb3.load as ill
+from ilamb3.tests.test_dataset import generate_test_dset
+
+
+@pytest.fixture
+def df():
+    ds = generate_test_dset(seed=1)
+    path = str(Path(tempfile.gettempdir()) / "tmp.nc")
+    ds.to_netcdf(path)
+    return pd.DataFrame(
+        [
+            {"path": path, "frequency": None},
+            {"path": path, "frequency": "mon"},
+            {"path": path, "frequency": "junk"},
+        ]
+    )
+
+
+def test_add_frequency_column(df):
+    df = ill.add_frequency_column(df)
+    assert (df["frequency"] == "mon").all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dependencies = [
 [dependency-groups]
 dev = ["pytest", "pytest-cov"]
 docs = [
-    "intake-esgf>=2025.10.22",
-    "ipykernel>=7.2.0",
-    "jupyter>=1.1.1",
-    "jupyterlab-myst>=2.6.0",
-    "mystmd>=1.8.3",
+  "intake-esgf>=2025.10.22",
+  "ipykernel>=7.2.0",
+  "jupyter>=1.1.1",
+  "jupyterlab-myst>=2.6.0",
+  "mystmd>=1.8.3",
 ]
 gcb = ["gsw>=3.6.19"]
 parallel = ["mpi4py>=4.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ ilamb3 = ["templates/*.html"]
 
 [tool.pytest.ini_options]
 console_output_style = "count"
-addopts = "--cov=ilamb3 --cov-report=xml --verbose"
+addopts = "--cov=ilamb3 --cov-report=xml --verbose -m 'not (parallel)'"
+markers = ["parallel: requires mpi4py installed"]
 
 [tool.coverage.run]
 omit = ["*/ilamb3/tests/*", "*/ilamb3/_version.py"]


### PR DESCRIPTION
- The analysis modules themselves can check if a time frequency is inappropriate for the analysis we are doing and raise AnalysisNotAppropriate. So I think we do not need for these objects to tell `ilamb3` what frequency they need.
- When we load the reference data, we can compute the time frequency and then in the case that models have multiple frequencies of one variable, we pick the frequency that most closely matches the reference data.
- The code can expect a ‘frequency’ column in the model database and if it is not there, we can just compute it for just the small piece of the dataframe being used in any analysis block.

As I think about what impact this would have on how we would use the feature, this scenario comes to mind:

- You have AMF daily gpp data as a reference
- You have model data that has both monthly and daily gpp
- You want to run the bias, RMSE and diurnal (does not exist yet) analysis modules

Using the above approach, ilamb would pick the daily model data for this block because that matches the time frequency of the reference data. This is needed for the diurnal analysis module but the others could have made use of the monthly data to compute faster.  The answers wouldn't be wrong, it is just that it would take longer to run. I think this is a fine penalty.

If the user wanted to avoid this, they would have 2 blocks for the AMF gpp comparision. One in which they specify monthly AMF data and run bias and RMSE. A second in which they specify the daily AMF data and run the diurnal cycle.

This does come at the cost of computing the time frequency of everything in the model dataframe. This could take time, but again it can be avoided by users having the frequency column in their dataframe *a priori*.