### PR TITLE
FIX: bugs / improvements as we run on OLCF

### DIFF
--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -15,6 +15,7 @@ import pandas as pd
 import xarray as xr
 
 import ilamb3
+import ilamb3.load as ill
 import ilamb3.plot as ilp
 from ilamb3.analysis.base import ILAMBAnalysis
 from ilamb3.exceptions import MissingVariable
@@ -60,9 +61,8 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
         **kwargs: Any,
     ):
         # Register basins in the ILAMB region system
-        cat = ilamb3.ilamb_catalog()
         self.basins = list(
-            set(Regions().add_netcdf(xr.open_dataset(cat.fetch("G-RUN/mrb_basins.nc"))))
+            set(Regions().add_netcdf(ill.load_key_or_filename("G-RUN/mrb_basins.nc")))
         )
         self.output_path = Path(output_path) if output_path is not None else None
 

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -111,7 +111,7 @@ def run(
     region_source: Annotated[
         list[Path] | None,
         typer.Option(
-            help="The file (text or netCDF) which provides more regions over which the analysis may be run. Use the option multiple times to specify multiple files."
+            help="The file or key which provides more regions over which the analysis may be run. Use the option multiple times to specify multiple files."
         ),
     ] = None,
     output_path: Annotated[
@@ -142,9 +142,11 @@ def run(
     ] = None,
 ):
     ilamb3.conf.reset()
-    region_source = list() if region_source is None else region_source
-    ilamb3.conf["region_sources"] = region_source
-    for source in region_source:
+    region_sources = (
+        list() if region_source is None else [str(r) for r in region_source]
+    )
+    ilamb3.conf["region_sources"] = region_sources
+    for source in region_sources:
         ilr.Regions().add_netcdf(ill.load_key_or_filename(str(source)))
 
     # set options

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -102,8 +102,8 @@ def run(
             help="The model database file(s) in CSV format. Use the option multiple times to specify multiple files."
         ),
     ],
-    regions: Annotated[
-        str | None,
+    region: Annotated[
+        list[str] | None,
         typer.Option(
             help="The region label over which the analysis is run. Use the option multiple times to specify multiple regions."
         ),
@@ -142,15 +142,14 @@ def run(
     ] = None,
 ):
     ilamb3.conf.reset()
-    if region_source is not None:
-        cat = ilamb3.ilamb_catalog()
-        for source in region_source:
-            ilr.Regions().add_netcdf(cat.fetch(source))
-        ilamb3.conf["region_sources"] = region_source
+    region_source = list() if region_source is None else region_source
+    ilamb3.conf["region_sources"] = region_source
+    for source in region_source:
+        ilr.Regions().add_netcdf(ill.load_key_or_filename(str(source)))
 
     # set options
     ilamb3.conf.set(
-        regions=regions,
+        regions=region,
         use_cached_results=cache,
         use_uncertainty=True,
         plot_central_longitude=central_longitude,
@@ -162,9 +161,9 @@ def run(
     # load local databases
     df_ref = form_reference_dataframe(parse_registry_keys(config))
     if df_ref["path"].isnull().any():
-        config = str(config)
+        sconfig = str(config)
         raise ValueError(
-            f"Some of the reference data keys you specify in {config=} is not locally available: {list(df_ref[df_ref['path'].isnull()].index)}.\nRun `ilamb fetch {config}` to download files locally."
+            f"Some of the reference data keys you specify in {sconfig=} is not locally available: {list(df_ref[df_ref['path'].isnull()].index)}.\nRun `ilamb fetch {sconfig}` to download files locally."
         )
     df_com = pd.concat([pd.read_csv(f) for f in model_db])
     df_com = ill.add_frequency_column(df_com)
@@ -172,14 +171,14 @@ def run(
     # execute
     if HAS_MPI4PY:
         run_study_parallel(
-            config,
+            str(config),
             df_com,
             df_ref,
             output_path=output_path,
         )
     else:
         run_study(
-            config,
+            str(config),
             df_com,
             ref_datasets=df_ref,
             output_path=output_path,
@@ -198,7 +197,7 @@ def fetch(
     df = form_reference_dataframe(parse_registry_keys(config))
     df = df[df["path"].isnull()]
     for key in df.index:
-        fetch_key(key, catalogs)
+        fetch_key(str(key), catalogs)
 
 
 @app.command(help="What went wrong in the run?")

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -192,12 +192,19 @@ def run(
 @app.command(help="Fetch reference data if part of an ILAMB catalog.")
 def fetch(
     config: Annotated[Path, typer.Argument(help="The benchmark study yaml file.")],
+    key: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Additional keys to fetch from the catalog. Especially useful to pre-download region files prior to running the study. Use the option multiple times to specify multiple files."
+        ),
+    ] = None,
 ):
     catalogs = [ilamb3.ilamb_catalog(), ilamb3.iomb_catalog(), ilamb3.ilamb3_catalog()]
     df = form_reference_dataframe(parse_registry_keys(config))
     df = df[df["path"].isnull()]
-    for key in df.index:
-        fetch_key(str(key), catalogs)
+    keys = [str(key) for key in df.index] + (key or [])
+    for download_key in keys:
+        fetch_key(download_key, catalogs)
 
 
 @app.command(help="What went wrong in the run?")

--- a/ilamb3/cli/__init__.py
+++ b/ilamb3/cli/__init__.py
@@ -191,7 +191,9 @@ def run(
 
 @app.command(help="Fetch reference data if part of an ILAMB catalog.")
 def fetch(
-    config: Annotated[Path, typer.Argument(help="The benchmark study yaml file.")],
+    config: Annotated[
+        Path | None, typer.Argument(help="The benchmark study yaml file.")
+    ] = None,
     key: Annotated[
         list[str] | None,
         typer.Option(
@@ -200,9 +202,12 @@ def fetch(
     ] = None,
 ):
     catalogs = [ilamb3.ilamb_catalog(), ilamb3.iomb_catalog(), ilamb3.ilamb3_catalog()]
-    df = form_reference_dataframe(parse_registry_keys(config))
-    df = df[df["path"].isnull()]
-    keys = [str(key) for key in df.index] + (key or [])
+    keys = []
+    if config is not None:
+        df = form_reference_dataframe(parse_registry_keys(config))
+        df = df[df["path"].isnull()]  # just the datasets we don't have
+        keys += [str(key) for key in df.index]
+    keys += key or []
     for download_key in keys:
         fetch_key(download_key, catalogs)
 

--- a/ilamb3/configure/ilamb.yaml
+++ b/ilamb3/configure/ilamb.yaml
@@ -1,65 +1,61 @@
 Ecosystem and Carbon Cycle:
-
   Biomass:
-
     Thurner:
       sources:
         biomass: biomass/Thurner/biomass_0.5x0.5.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     XuSaatchi2021:
       sources:
         biomass: biomass/XuSaatchi2021/XuSaatchi.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     USForest:
       sources:
         biomass: biomass/USForest/biomass_0.5x0.5.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     ESACCI:
       sources:
         biomass: biomass/ESACCI/biomass.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     Saatchi2011:
       sources:
         biomass: biomass/Saatchi2011/biomass_0.5x0.5.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     NBCD2000:
       sources:
         biomass: biomass/NBCD2000/biomass_0.5x0.5.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
     GEOCARBON:
       sources:
         biomass: biomass/GEOCARBON/biomass.nc
       alternate_vars:
-      - cVeg
+        - cVeg
       variable_cmap: Greens
 
   Burnt Area:
-
     GFED-5-0:
       sources:
         burntFractionAll: GFED-5-0/obs4MIPs_NASA-NOSR_GFED-5-0_mon_burntFractionAll_gr_v20260302.nc
       variable_cmap: YlOrBr
 
   Gross Primary Productivity:
-
     Fluxnet-2015:
       sources:
         gpp: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_gpp_site_v20260302.nc
@@ -90,7 +86,6 @@ Ecosystem and Carbon Cycle:
       plot_unit: g m-2 d-1
 
   Leaf Area Index:
-
     GIMMS_LAI4g:
       sources:
         lai: lai/GIMMS_LAI4g/cao2023_lai.nc
@@ -120,54 +115,50 @@ Ecosystem and Carbon Cycle:
       variable_cmap: Greens
 
   Global Net Ecosystem Carbon Balance:
-
     Hoffman-1-0:
       sources:
         nbp: Hoffman-1-0/obs4MIPs_UCI-ORNL_Hoffman-1-0_yr_nbp_gm_v20260302.nc
       transforms:
-      - integrate_space:
-          varname: nbp
+        - integrate_space:
+            varname: nbp
       analyses:
-      - nbp
+        - nbp
 
     GCP:
       sources:
         nbp: nbp/GCP/nbp_1959-2016.nc
       transforms:
-      - integrate_space:
-          varname: nbp
+        - integrate_space:
+            varname: nbp
       analyses:
-      - nbp
+        - nbp
       evaluation_year: 2014
 
   Net Ecosystem Exchange:
-
     Fluxnet-2015:
       sources:
         nee: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_nee_site_v20260302.nc
       transforms:
-      - expression:
-          expr: "nee = ra + rh - gpp"
+        - expression:
+            expr: "nee = ra + rh - gpp"
       variable_cmap: Greens
 
   Ecosystem Respiration:
-
     Fluxnet-2015:
       sources:
         reco: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_reco_site_v20260302.nc
       transforms:
-      - expression:
-          expr: "reco = ra + rh"
+        - expression:
+            expr: "reco = ra + rh"
 
     FLUXCOM-1:
       sources:
         reco: FLUXCOM-1/obs4MIPs_MPI-BGC-BGI_FLUXCOM-1_mon_reco_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "reco = ra + rh"
+        - expression:
+            expr: "reco = ra + rh"
 
   Soil Carbon:
-
     Wang2024:
       sources:
         cSoil: cSoil/Wang2024/wang2024_cSoil.nc
@@ -180,10 +171,9 @@ Ecosystem and Carbon Cycle:
       sources:
         cSoilAbove1m: cSoil/NCSCDV22/soilc_0.5x0.5.nc
       alternate_vars:
-      - cSoil
+        - cSoil
 
   Nitrogen Fixation:
-
     Davies-Barnard:
       sources:
         fBNF: fBNF/DaviesBarnard/fBNF_0.5x0.5.nc
@@ -193,9 +183,7 @@ Ecosystem and Carbon Cycle:
       plot_unit: kg ha-1 yr-1
 
 Hydrology Cycle:
-
   Evapotranspiration:
-
     MOD16A2:
       sources:
         et: evspsbl/MOD16A2/et.nc
@@ -204,7 +192,7 @@ Hydrology Cycle:
         tas: tas/CRU4.02/tas.nc
       variable_cmap: Blues
       alternate_vars:
-      - evspsbl
+        - evspsbl
 
     MODIS:
       sources:
@@ -214,7 +202,7 @@ Hydrology Cycle:
         tas: tas/CRU4.02/tas.nc
       variable_cmap: Blues
       alternate_vars:
-      - evspsbl
+        - evspsbl
 
     GLEAMv3.3a:
       sources:
@@ -224,27 +212,26 @@ Hydrology Cycle:
         tas: tas/CRU4.02/tas.nc
       variable_cmap: Blues
       alternate_vars:
-      - evspsbl
+        - evspsbl
 
   Evaporative Fraction:
-
     WECANN-1-0:
       analysis_variable: evapfrac
       sources:
         hfss: WECANN-1-0/obs4MIPs_ColumbiaU_WECANN-1-0_mon_hfss_gn_v20260302.nc
         hfls: WECANN-1-0/obs4MIPs_ColumbiaU_WECANN-1-0_mon_hfls_gn_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 2007-01
-          vmax: 2015-01
-      - integrate_time:
-          varname: hfss
-          mean: true
-      - integrate_time:
-          varname: hfls
-          mean: true
-      - expression:
-          expr: "evapfrac = hfls / (hfls + hfss)"
+        - select_time:
+            vmin: 2007-01
+            vmax: 2015-01
+        - integrate_time:
+            varname: hfss
+            mean: true
+        - integrate_time:
+            varname: hfls
+            mean: true
+        - expression:
+            expr: "evapfrac = hfls / (hfls + hfss)"
 
     CLASS-1-1:
       analysis_variable: evapfrac
@@ -252,17 +239,17 @@ Hydrology Cycle:
         hfss: CLASS-1-1/obs4MIPs_UNSW_CLASS-1-1_mon_hfss_gn_v20260302.nc
         hfls: CLASS-1-1/obs4MIPs_UNSW_CLASS-1-1_mon_hfls_gn_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 2003-01
-          vmax: 2009-12
-      - integrate_time:
-          varname: hfss
-          mean: true
-      - integrate_time:
-          varname: hfls
-          mean: true
-      - expression:
-          expr: "evapfrac = hfls / (hfls + hfss)"
+        - select_time:
+            vmin: 2003-01
+            vmax: 2009-12
+        - integrate_time:
+            varname: hfss
+            mean: true
+        - integrate_time:
+            varname: hfls
+            mean: true
+        - expression:
+            expr: "evapfrac = hfls / (hfls + hfss)"
 
     Fluxnet-2015:
       analysis_variable: evapfrac
@@ -270,20 +257,19 @@ Hydrology Cycle:
         hfss: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_hfss_site_v20260302.nc
         hfls: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_hfls_site_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 1991-01
-          vmax: 2015-01
-      - integrate_time:
-          varname: hfss
-          mean: true
-      - integrate_time:
-          varname: hfls
-          mean: true
-      - expression:
-          expr: "evapfrac = hfls / (hfls + hfss)"
+        - select_time:
+            vmin: 1991-01
+            vmax: 2015-01
+        - integrate_time:
+            varname: hfss
+            mean: true
+        - integrate_time:
+            varname: hfls
+            mean: true
+        - expression:
+            expr: "evapfrac = hfls / (hfls + hfss)"
 
   Latent Heat:
-
     Fluxnet-2015:
       sources:
         hfls: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_hfls_site_v20260302.nc
@@ -310,7 +296,6 @@ Hydrology Cycle:
       variable_cmap: Blues
 
   Runoff:
-
     LORA-1-0:
       sources:
         mrro: LORA-1-0/obs4MIPs_ARCCSS_LORA-1-0_mon_mrro_gn_v20260302.nc
@@ -322,7 +307,6 @@ Hydrology Cycle:
       variable_cmap: Blues
 
   Sensible Heat:
-
     Fluxnet-2015:
       sources:
         hfss: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_hfss_site_v20260302.nc
@@ -344,52 +328,47 @@ Hydrology Cycle:
       variable_cmap: Blues
 
   Surface Soil Moisture:
-
     WangMao:
       sources:
         mrsol: mrsol/WangMao/mrsol_olc.nc
       variable_cmap: Blues
       transforms:
-      - soil_moisture_to_vol_fraction
-      - select_depth:
-          value: 0
+        - soil_moisture_to_vol_fraction
+        - select_depth:
+            value: 0
       alternate_vars:
-      - mrsos
+        - mrsos
 
   Soil Moisture 1m:
-
     WangMao:
       sources:
         mrsol: mrsol/WangMao/mrsol_olc.nc
       variable_cmap: Blues
       transforms:
-      - soil_moisture_to_vol_fraction
-      - select_depth:
-          value: 1.
+        - soil_moisture_to_vol_fraction
+        - select_depth:
+            value: 1.
 
 Cryosphere:
-
   Snow Cover:
-
     CCI-CryoClim-FSC-1:
       sources:
         snc: CCI-CryoClim-FSC-1/snc_mon_Snow-cci_BE_gn_198201-201906.nc
       variable_cmap: BuPu
 
   Permafrost Extent:
-
     Brown2002:
       sources:
         permafrost_extent: permafrost/Brown2002/Brown2002.nc
       transforms:
-      - select_time:
-          vmin: 1960-01
-          vmax: 1993-01
-      - select_lat:
-          vmin: 30.
-          vmax: 90.
-      - permafrost_extent:
-          method: slater2013
+        - select_time:
+            vmin: 1960-01
+            vmax: 1993-01
+        - select_lat:
+            vmin: 30.
+            vmax: 90.
+        - permafrost_extent:
+            method: slater2013
       analyses:
         - area
 
@@ -397,53 +376,50 @@ Cryosphere:
       sources:
         permafrost_extent: permafrost/Obu2018/Obu2018.nc
       transforms:
-      - select_time:
-          vmin: 2000-01
-          vmax: 2016-01
-      - select_lat:
-          vmin: -10.
-          vmax: 90.
-      - permafrost_extent:
-          method: slater2013
+        - select_time:
+            vmin: 2000-01
+            vmax: 2016-01
+        - select_lat:
+            vmin: -10.
+            vmax: 90.
+        - permafrost_extent:
+            method: slater2013
       analyses:
         - area
 
   Active Layer Thickness:
-
     CALM:
       sources:
         active_layer_thickness: active_layer_thickness/CALM/CALM_1990-2024.nc
       transforms:
-      - select_time:
-          vmin: 1990-01
-          vmax: 2023-01
-      - select_lat:
-          vmin: 30.
-          vmax: 90.
-      - active_layer_thickness:
-          method: slater2013
+        - select_time:
+            vmin: 1990-01
+            vmax: 2023-01
+        - select_lat:
+            vmin: 30.
+            vmax: 90.
+        - active_layer_thickness:
+            method: slater2013
 
 Radiation and Energy Cycle:
-
   Albedo:
-
     CERES-EBAF-4-2-1:
       analysis_variable: albedo
       sources:
         rsus: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rsus_gn_v20260302.nc
         rsds: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rsds_gn_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 2000-03
-          vmax: 2015-01
-      - integrate_time:
-          varname: rsus
-          mean: true
-      - integrate_time:
-          varname: rsds
-          mean: true
-      - expression:
-          expr: "albedo = rsus / rsds"
+        - select_time:
+            vmin: 2000-03
+            vmax: 2015-01
+        - integrate_time:
+            varname: rsus
+            mean: true
+        - integrate_time:
+            varname: rsds
+            mean: true
+        - expression:
+            expr: "albedo = rsus / rsds"
 
     Fluxnet-2015:
       analysis_variable: albedo
@@ -451,17 +427,17 @@ Radiation and Energy Cycle:
         rsus: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rsus_site_v20260302.nc
         rsds: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rsds_site_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 1991-01
-          vmax: 2015-01
-      - integrate_time:
-          varname: rsus
-          mean: true
-      - integrate_time:
-          varname: rsds
-          mean: true
-      - expression:
-          expr: "albedo = rsus / rsds"
+        - select_time:
+            vmin: 1991-01
+            vmax: 2015-01
+        - integrate_time:
+            varname: rsus
+            mean: true
+        - integrate_time:
+            varname: rsds
+            mean: true
+        - expression:
+            expr: "albedo = rsus / rsds"
 
     GEWEX-SRB-4-IP:
       analysis_variable: albedo
@@ -469,20 +445,19 @@ Radiation and Energy Cycle:
         rsus: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsus_gn_v20260302.nc
         rsds: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsds_gn_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 1988-01
-          vmax: 2009-12
-      - integrate_time:
-          varname: rsus
-          mean: true
-      - integrate_time:
-          varname: rsds
-          mean: true
-      - expression:
-          expr: "albedo = rsus / rsds"
+        - select_time:
+            vmin: 1988-01
+            vmax: 2009-12
+        - integrate_time:
+            varname: rsus
+            mean: true
+        - integrate_time:
+            varname: rsds
+            mean: true
+        - expression:
+            expr: "albedo = rsus / rsds"
 
   Surface Upward SW Radiation:
-
     Fluxnet-2015:
       sources:
         rsus: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rsus_site_v20260302.nc
@@ -504,7 +479,6 @@ Radiation and Energy Cycle:
       variable_cmap: RdPu
 
   Surface Upward LW Radiation:
-
     Fluxnet-2015:
       sources:
         rlus: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rlus_site_v20260302.nc
@@ -526,13 +500,12 @@ Radiation and Energy Cycle:
       variable_cmap: RdPu
 
   Surface Net SW Radiation:
-
     Fluxnet-2015:
       sources:
         rns: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rns_site_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rsds - rsus"
+        - expression:
+            expr: "rns = rsds - rsus"
       variable_cmap: RdPu
 
     CERES-EBAF-4-2-1:
@@ -540,8 +513,8 @@ Radiation and Energy Cycle:
       sources:
         rss: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rss_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rss = rsds - rsus"
+        - expression:
+            expr: "rss = rsds - rsus"
       variable_cmap: RdPu
 
     GEWEX-SRB-4-IP:
@@ -550,36 +523,35 @@ Radiation and Energy Cycle:
         rsds: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsds_gn_v20260302.nc
         rsus: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsus_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rsds - rsus"
+        - expression:
+            expr: "rns = rsds - rsus"
       variable_cmap: RdPu
 
     WRMC.BSRN:
       sources:
         rsns: rsns/WRMC.BSRN/rsns.nc
       transforms:
-      - expression:
-          expr: "rsns = rsds - rsus"
+        - expression:
+            expr: "rsns = rsds - rsus"
       variable_cmap: RdPu
 
   Surface Net LW Radiation:
-
     Fluxnet-2015:
       analysis_variable: rls
       sources:
         rlds: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rlds_site_v20260302.nc
         rlus: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rlus_site_v20260302.nc
       transforms:
-      - expression:
-          expr: "rls = rlds - rlus"
+        - expression:
+            expr: "rls = rlds - rlus"
       variable_cmap: RdPu
 
     CERES-EBAF-4-2-1:
       sources:
         rls: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rls_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rls = rlds - rlus"
+        - expression:
+            expr: "rls = rlds - rlus"
       variable_cmap: RdPu
 
     GEWEX-SRB-4-IP:
@@ -588,26 +560,25 @@ Radiation and Energy Cycle:
         rlds: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rlds_gn_v20260302.nc
         rlus: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rlus_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rls = rlds - rlus"
+        - expression:
+            expr: "rls = rlds - rlus"
       variable_cmap: RdPu
 
     WRMC.BSRN:
       sources:
         rlns: rlns/WRMC.BSRN/rlns.nc
       transforms:
-      - expression:
-          expr: "rlns = rlds - rlus"
+        - expression:
+            expr: "rlns = rlds - rlus"
       variable_cmap: RdPu
 
   Surface Net Radiation:
-
     Fluxnet-2015:
       sources:
         rns: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rns_site_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rlds - rlus + rsds - rsus"
+        - expression:
+            expr: "rns = rlds - rlus + rsds - rsus"
       variable_cmap: RdPu
 
     CERES-EBAF-4-2-1:
@@ -618,8 +589,8 @@ Radiation and Energy Cycle:
         rsds: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rsds_gn_v20260302.nc
         rsus: CERES-EBAF-4-2-1/obs4MIPs_NASA-LaRC_CERES-EBAF-4-2-1_mon_rsus_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rlds - rlus + rsds - rsus"
+        - expression:
+            expr: "rns = rlds - rlus + rsds - rsus"
       variable_cmap: RdPu
 
     GEWEX-SRB-4-IP:
@@ -630,30 +601,28 @@ Radiation and Energy Cycle:
         rsds: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsds_gn_v20260302.nc
         rsus: GEWEX-SRB-4-IP/obs4MIPs_NASA-LaRC_GEWEX-SRB-4-IP_mon_rsus_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rlds - rlus + rsds - rsus"
+        - expression:
+            expr: "rns = rlds - rlus + rsds - rsus"
       variable_cmap: RdPu
 
     WRMC.BSRN:
       sources:
         rns: rns/WRMC.BSRN/rns.nc
       transforms:
-      - expression:
-          expr: "rns = rlds - rlus + rsds - rsus"
+        - expression:
+            expr: "rns = rlds - rlus + rsds - rsus"
       variable_cmap: RdPu
 
     CLASS-1-1:
       sources:
         rns: CLASS-1-1/obs4MIPs_UNSW_CLASS-1-1_mon_rns_gn_v20260302.nc
       transforms:
-      - expression:
-          expr: "rns = rlds - rlus + rsds - rsus"
+        - expression:
+            expr: "rns = rlds - rlus + rsds - rsus"
       variable_cmap: RdPu
 
 Forcings:
-
   Surface Air Temperature:
-
     Fluxnet-2015:
       sources:
         tas: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_tas_site_v20260302.nc
@@ -665,31 +634,27 @@ Forcings:
       variable_cmap: cool
 
   Diurnal Maximum Temperature:
-
     CRU4.02:
       sources:
         tasmax: tasmax/CRU4.02/tasmax.nc
       variable_cmap: cool
 
   Diurnal Minimum Temperature:
-
     CRU4.02:
       sources:
         tasmin: tasmin/CRU4.02/tasmin.nc
       variable_cmap: cool
 
   Diurnal Temperature Range:
-
     CRU4.02:
       sources:
         dtr: dtr/CRU4.02/dtr.nc
       variable_cmap: cool
       transforms:
-      - expression:
-          expr: "dtr = tasmax - tasmin"
+        - expression:
+            expr: "dtr = tasmax - tasmin"
 
   Precipitation:
-
     CMAPv1904:
       sources:
         pr: pr/CMAPv1904/pr.nc
@@ -716,16 +681,14 @@ Forcings:
       variable_cmap: Blues
 
   Surface Relative Humidity:
-
     CRU4.02:
       sources:
         rhums: rhums/CRU4.02/rhums.nc
       variable_cmap: Blues
     alternate_vars:
-    - hurs
+      - hurs
 
   Surface Downward SW Radiation:
-
     Fluxnet-2015:
       sources:
         rsds: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rsds_site_v20260302.nc
@@ -747,7 +710,6 @@ Forcings:
       variable_cmap: RdPu
 
   Surface Downward LW Radiation:
-
     Fluxnet-2015:
       sources:
         rlds: Fluxnet-2015/obs4MIPs_Fluxnet_Fluxnet-2015_mon_rlds_site_v20260302.nc
@@ -769,16 +731,14 @@ Forcings:
       variable_cmap: RdPu
 
 Sensitivities:
-
   Runoff:
-
     G-RUN:
       sources:
         psens_obs: G-RUN/runoff_sensitivity_obs.nc
       transforms:
-      - select_time:
-          vmin: 1940-01
-          vmax: 2015-01
-      - runoff_sensitivity
+        - select_time:
+            vmin: 1940-01
+            vmax: 2015-01
+        - runoff_sensitivity
       analyses:
-      - Runoff Sensitivity
+        - Runoff Sensitivity

--- a/ilamb3/configure/ilamb.yaml
+++ b/ilamb3/configure/ilamb.yaml
@@ -391,7 +391,7 @@ Cryosphere:
       - permafrost_extent:
           method: slater2013
       analyses:
-      - Area Comparison
+        - area
 
     Obu2018:
       sources:
@@ -406,7 +406,7 @@ Cryosphere:
       - permafrost_extent:
           method: slater2013
       analyses:
-      - Area Comparison
+        - area
 
   Active Layer Thickness:
 

--- a/ilamb3/configure/ilamb.yaml
+++ b/ilamb3/configure/ilamb.yaml
@@ -741,4 +741,4 @@ Sensitivities:
             vmax: 2015-01
         - runoff_sensitivity
       analyses:
-        - Runoff Sensitivity
+        - runoff_sensitivity

--- a/ilamb3/configure/iomb.yaml
+++ b/ilamb3/configure/iomb.yaml
@@ -1,245 +1,225 @@
-
 Ecosystems:
-
   Chlorophyll:
-
     GLODAP2.2022:
       sources:
         chla: GLODAP2.2022/chla.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - chl
+        - chl
 
     SeaWIFS:
       sources:
         chl: SeaWIFS/SeaWIFS.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
     MODISAqua:
       sources:
         chl: MODISAqua/MODISAqua.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
   Oxygen Surface:
-
     WOA-23:
       sources:
         o2: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_o2_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
     GLODAP2.2022:
       sources:
         o2: GLODAP2.2022/o2.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
 Nutrients:
-
   Nitrate Surface:
-
     WOA-23:
       sources:
         no3: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_no3_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
     GLODAP2.2022:
       sources:
         no3: GLODAP2.2022/no3.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
   Phosphate Surface:
-
     WOA-23:
       sources:
         po4: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_po4_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
     GLODAP2.2022:
       sources:
         po4: GLODAP2.2022/po4.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
   Silicate Surface:
-
     WOA-23:
       sources:
         si: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_si_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
     GLODAP2.2022:
       sources:
         sio3: GLODAP2.2022/sio3.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - si
+        - si
 
 Carbon:
-
   Alkalinity:
-
     GLODAP2.2022:
       sources:
         talk: GLODAP2.2022/talk.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
   Dissolved Inorganic Carbon:
-
     GLODAP2.2022:
       sources:
         dissic: GLODAP2.2022/dissic.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
 
 Physical Drivers:
-
   Mixed Layer Depth:
-
     Boyer:
       sources:
         mlotstmax: Boyer/mlotstmax.nc
       alternate_vars:
-      - omlmax
+        - omlmax
 
   Temperature Surface:
-
     WOA-23:
       sources:
         thetao: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_thetao_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - tos
+        - tos
 
     GLODAP2.2022:
       sources:
         thetao: GLODAP2.2022/thetao.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - tos
+        - tos
 
   Temperature 200m:
-
     WOA-23:
       sources:
         thetao: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_thetao_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 200.
+        - select_depth:
+            value: 200.
 
     GLODAP2.2022:
       sources:
         thetao: GLODAP2.2022/thetao.nc
       transforms:
-      - select_depth:
-          value: 200.
+        - select_depth:
+            value: 200.
 
   Temperature 700m:
-
     WOA-23:
       sources:
         thetao: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_thetao_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 700.
+        - select_depth:
+            value: 700.
 
     GLODAP2.2022:
       sources:
         thetao: GLODAP2.2022/thetao.nc
       transforms:
-      - select_depth:
-          value: 700.
+        - select_depth:
+            value: 700.
 
   Vertical Temperature Gradient:
-
     WOA-23:
       sources:
         thetao: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_thetao_gn_v20260302.nc
       transforms:
-      - select_time:
-          vmin: 1955-01
-          vmax: 2023-01
-      - select_depth:
-          vmin: 200.
-          vmax: 1000.
-      - depth_gradient
+        - select_time:
+            vmin: 1955-01
+            vmax: 2023-01
+        - select_depth:
+            vmin: 200.
+            vmax: 1000.
+        - depth_gradient
       plot_unit: delta_degC km-1
       table_unit: delta_degC km-1
 
   Salinity Surface:
-
     WOA-23:
       sources:
         so: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_so_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - sos
+        - sos
 
     GLODAP2.2022:
       sources:
         so: GLODAP2.2022/so.nc
       transforms:
-      - select_depth:
-          value: 0.
+        - select_depth:
+            value: 0.
       alternate_vars:
-      - sos
+        - sos
 
   Salinity 200m:
-
     WOA-23:
       sources:
         so: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_so_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 200.
+        - select_depth:
+            value: 200.
 
     GLODAP2.2022:
       sources:
         so: GLODAP2.2022/so.nc
       transforms:
-      - select_depth:
-          value: 200.
+        - select_depth:
+            value: 200.
 
   Salinity 700m:
-
     WOA-23:
       sources:
         so: WOA-23/obs4MIPs_NOAA-NCEI-OCL_WOA-23_monC_so_gn_v20260302.nc
       transforms:
-      - select_depth:
-          value: 700.
+        - select_depth:
+            value: 700.
 
     GLODAP2.2022:
       sources:
         so: GLODAP2.2022/so.nc
       transforms:
-      - select_depth:
-          value: 700.
+        - select_depth:
+            value: 700.

--- a/ilamb3/dataset.py
+++ b/ilamb3/dataset.py
@@ -1277,3 +1277,25 @@ def cmip_cell_measures(ds: xr.Dataset, varname: str) -> xr.Dataset:
     msr = xr.where(msr > 0, msr, np.nan)
     ds["cell_measures"] = msr
     return ds
+
+
+def which_cell_measures(
+    data: xr.Dataset | xr.DataArray, varname: str | None
+) -> list[str]:
+    """
+    Return the name of the cell measures variable for the given variable, if present.
+    """
+    if isinstance(data, xr.Dataset) and varname is None:
+        raise ValueError("varname must be specified when data is a Dataset")
+    da = data if isinstance(data, xr.DataArray) else data[varname]
+    measures = []
+    if "cell_measures" in da.attrs:
+        m = re.search(r"area:\s(.*)", da.attrs["cell_measures"])
+        if m:
+            measures.append(m.group(1))
+    if "cell_methods" in da.attrs:
+        if "where land" in da.attrs["cell_methods"]:
+            measures.append("sftlf")
+        elif "where sea" in da.attrs["cell_methods"]:
+            measures.append("sftof")
+    return measures

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -2,6 +2,8 @@
 Functions encapsulating the logic of how ilamb3 loads data during a run.
 """
 
+import functools
+import operator
 import os
 from collections.abc import Callable
 from functools import partial
@@ -281,6 +283,19 @@ def load_comparison_data(
         )
         for var in df["variable_id"].unique()
     }
+    # Remove measure variables that aren't needed, we don't know until the
+    # datasets are loaded
+    measures_used = functools.reduce(
+        operator.or_,
+        [
+            set(dset.which_cell_measures(ds, var))
+            for var, ds in com.items()
+            if var not in ["areacella", "sftlf", "areacello", "sftof"]
+        ],
+    )
+    for unused in set(["areacella", "sftlf", "areacello", "sftof"]) - measures_used:
+        com.pop(unused)
+
     # If the variable_id is not present, it may be called something else
     if alternate_vars is not None and variable_id not in com:
         found = [v for v in alternate_vars if v in com]

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -12,10 +12,50 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+import ilamb3
 import ilamb3.compare as cmp
 import ilamb3.dataset as dset
 from ilamb3.exceptions import VarNotInModel
 from ilamb3.transform.base import ILAMBTransform
+
+
+def load_key_or_filename(asset_name: str) -> xr.Dataset:
+    """
+    Load an asset using the following priority:
+
+    1. If a key in our registry, load/download and open with xarray.
+    2. If not, treat it as an absolute path and open with xarray.
+    3. Finally check if a relative path to the ILAMB_ROOT environment variable.
+
+    Parameters
+    ----------
+    asset_name : str
+        The name of the asset to load.
+
+    Returns
+    -------
+    xr.Dataset
+        The loaded dataset.
+    """
+    # First check each catalog
+    for cat in [ilamb3.ilamb3_catalog(), ilamb3.ilamb_catalog(), ilamb3.iomb_catalog()]:
+        try:
+            ds = xr.open_dataset(cat.fetch(asset_name))
+            return ds
+        except ValueError:
+            pass
+    # Next treat it like an absolute path
+    asset_path = Path(asset_name)
+    if asset_path.is_file():
+        ds = xr.open_dataset(asset_path)
+        return ds
+    # Finally treat it like relative to ILAMB_ROOT
+    if "ILAMB_ROOT" in os.environ:
+        asset_path = Path(os.environ["ILAMB_ROOT"]) / asset_path
+        if asset_path.is_file():
+            ds = xr.open_dataset(asset_path)
+            return ds
+    raise FileNotFoundError(f"Could not find {asset_name=}")
 
 
 def fix_pint_units(ds: xr.Dataset) -> xr.Dataset:

--- a/ilamb3/load.py
+++ b/ilamb3/load.py
@@ -294,7 +294,7 @@ def load_comparison_data(
         ],
     )
     for unused in set(["areacella", "sftlf", "areacello", "sftof"]) - measures_used:
-        com.pop(unused)
+        com.pop(unused, None)
 
     # If the variable_id is not present, it may be called something else
     if alternate_vars is not None and variable_id not in com:

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -154,6 +154,7 @@ def _perform_work_phase2(setup, output_path):
     local_path = output_path / setup["path"]
     log_file = local_path / "post.log"
     log_file.unlink(missing_ok=True)
+    setup = run.augment_setup_with_options(setup, pd.DataFrame())
     analyses = run.setup_analyses(setup, local_path)
 
     # get parallel worker information for logging
@@ -221,8 +222,7 @@ def _start_worker(cfg_path: Path):
     ilamb3.conf.load(cfg_path)
     ilamb_regions = ilr.Regions()
     for source in ilamb3.conf["region_sources"]:
-        cat = ilamb3.ilamb_catalog()
-        ilamb_regions.add_netcdf(cat.fetch(source))
+        ilamb_regions.add_netcdf(ill.load_key_or_filename(source))
 
 
 def run_study_parallel(

--- a/ilamb3/tests/test_load.py
+++ b/ilamb3/tests/test_load.py
@@ -1,9 +1,11 @@
+import os
 import tempfile
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
+import ilamb3
 import ilamb3.load as ill
 from ilamb3.tests.test_dataset import generate_test_dset
 
@@ -25,3 +27,14 @@ def df():
 def test_add_frequency_column(df):
     df = ill.add_frequency_column(df)
     assert (df["frequency"] == "mon").all()
+
+
+def test_load_key_or_filename():
+    # setup, make sure this asset exists
+    asset = Path(ilamb3.ilamb_catalog().fetch("regions/GlobalLand.nc"))
+    ill.load_key_or_filename("regions/GlobalLand.nc")
+    ill.load_key_or_filename(str(asset.absolute()))
+    os.environ["ILAMB_ROOT"] = str(asset.parent)
+    ill.load_key_or_filename("GlobalLand.nc")
+    with pytest.raises(FileNotFoundError):
+        ill.load_key_or_filename("not_a_file.nc")


### PR DESCRIPTION
- `ilamb fetch` would only grab keys in the given configure file but if running against regions, you would have to manually find the file. Added a `--key` option to the command that allows you to give more keys to download. Also relaxes the need to specify a configure file. You can just give `--key` options.
- When we renamed the analyses, finding them programmatically, we did not update the configure files and a few blocks were failing.
- My IDE is now forcing the indentation of lists underneath a dictionary key.
- We automatically include cell measure variables in the dataframes but when we load datasets they are all being loaded. This will cause ambiguity because ocean and land data get put in the same dataset so when we need a `lon` we get `lon` or `longitude`. I had to add logic after we load all the datasets to only keep the measures we really need.
- `region_sources` in the config were being saved as Paths, but not loaded as such. Force them into strings and add some more configure consistency in the parallel execution of ilamb.