### PR TITLE
align unequal-length monthly series in trim_time

### DIFF
--- a/ilamb3/compare/base.py
+++ b/ilamb3/compare/base.py
@@ -212,37 +212,27 @@ def trim_time(*args: xr.Dataset, **kwargs: xr.Dataset) -> tuple[xr.Dataset]:
     for key, arg in kwargs.items():
         kwargs[key] = arg.sel({dset.get_dim_name(arg, "time"): tslice})
 
-    # Align unequal-length monthly series on their (year, month) keys, leaving
-    # single-timestep means untouched.
+    # Align unequal-length monthly series on their (year, month) keys,
+    # leaving single-timestep means untouched.
+    # Assumes at most one timestep per month
+    def _month_keys(ds: xr.Dataset) -> list[tuple[int, int]]:
+        time = ds[dset.get_dim_name(ds, "time")]
+        return list(zip(time.dt.year.values.tolist(), time.dt.month.values.tolist()))
+
     temporal = [arg for arg in args + list(kwargs.values()) if dset.is_temporal(arg)]
-    sizes = {arg[dset.get_dim_name(arg, "time")].size for arg in temporal}
+    sizes = {len(_month_keys(arg)) for arg in temporal}
     if len(sizes) > 1 and min(sizes) > 1:
+        common = set.intersection(*[set(_month_keys(arg)) for arg in temporal])
 
-        def _month_keys(ds: xr.Dataset) -> set[tuple[int, int]]:
-            time = ds[dset.get_dim_name(ds, "time")]
-            return set(
-                zip(time.dt.year.values.tolist(), time.dt.month.values.tolist())
-            )
-
-        common = set.intersection(*[_month_keys(arg) for arg in temporal])
-
-        def _select_common(ds: xr.Dataset) -> xr.Dataset:
+        def _align(ds: xr.Dataset) -> xr.Dataset:
+            if not dset.is_temporal(ds):
+                return ds
             time_dim = dset.get_dim_name(ds, "time")
-            time = ds[time_dim]
-            keep = np.array(
-                [
-                    (year, month) in common
-                    for year, month in zip(
-                        time.dt.year.values.tolist(), time.dt.month.values.tolist()
-                    )
-                ]
-            )
-            return ds.isel({time_dim: np.flatnonzero(keep)})
+            keep = np.flatnonzero([key in common for key in _month_keys(ds)])
+            return ds.isel({time_dim: keep})
 
-        args = [_select_common(a) if dset.is_temporal(a) else a for a in args]
-        for key in list(kwargs.keys()):
-            if dset.is_temporal(kwargs[key]):
-                kwargs[key] = _select_common(kwargs[key])
+        args = [_align(a) for a in args]
+        kwargs = {key: _align(arg) for key, arg in kwargs.items()}
 
     # Conditional returns based on what was passed in
     if args and not kwargs:

--- a/ilamb3/compare/base.py
+++ b/ilamb3/compare/base.py
@@ -212,6 +212,38 @@ def trim_time(*args: xr.Dataset, **kwargs: xr.Dataset) -> tuple[xr.Dataset]:
     for key, arg in kwargs.items():
         kwargs[key] = arg.sel({dset.get_dim_name(arg, "time"): tslice})
 
+    # Align unequal-length monthly series on their (year, month) keys, leaving
+    # single-timestep means untouched.
+    temporal = [arg for arg in args + list(kwargs.values()) if dset.is_temporal(arg)]
+    sizes = {arg[dset.get_dim_name(arg, "time")].size for arg in temporal}
+    if len(sizes) > 1 and min(sizes) > 1:
+
+        def _month_keys(ds: xr.Dataset) -> set[tuple[int, int]]:
+            time = ds[dset.get_dim_name(ds, "time")]
+            return set(
+                zip(time.dt.year.values.tolist(), time.dt.month.values.tolist())
+            )
+
+        common = set.intersection(*[_month_keys(arg) for arg in temporal])
+
+        def _select_common(ds: xr.Dataset) -> xr.Dataset:
+            time_dim = dset.get_dim_name(ds, "time")
+            time = ds[time_dim]
+            keep = np.array(
+                [
+                    (year, month) in common
+                    for year, month in zip(
+                        time.dt.year.values.tolist(), time.dt.month.values.tolist()
+                    )
+                ]
+            )
+            return ds.isel({time_dim: np.flatnonzero(keep)})
+
+        args = [_select_common(a) if dset.is_temporal(a) else a for a in args]
+        for key in list(kwargs.keys()):
+            if dset.is_temporal(kwargs[key]):
+                kwargs[key] = _select_common(kwargs[key])
+
     # Conditional returns based on what was passed in
     if args and not kwargs:
         return args

--- a/ilamb3/tests/test_compare.py
+++ b/ilamb3/tests/test_compare.py
@@ -83,6 +83,28 @@ def test_trim_time():
     assert len(out2) == 2
 
 
+def test_trim_time_aligns_unequal_monthly_coverage():
+    # Reference is missing an interior month, so trim_time must still return
+    # equal-length, month-aligned series.
+    times = pd.date_range(start="2004-04-01", periods=130, freq="MS")
+    com = xr.Dataset(
+        {"amoc": xr.DataArray(np.arange(130.0), coords=[times], dims=["time"])}
+    )
+    com["amoc"].attrs["units"] = "1"
+    ref_times = times.delete(50)  # drop one interior month -> 129 points
+    ref = xr.Dataset(
+        {"amoc": xr.DataArray(np.arange(129.0), coords=[ref_times], dims=["time"])}
+    )
+    ref["amoc"].attrs["units"] = "1"
+
+    ref_out, com_out = cmp.trim_time(ref, com)
+
+    # Equal length and month-aligned, so the correlation no longer raises.
+    assert ref_out["time"].size == com_out["time"].size == 129
+    assert (ref_out["time"].values == com_out["time"].values).all()
+    np.corrcoef(ref_out["amoc"], com_out["amoc"].squeeze())
+
+
 def test_same_spatial_grid():
     grid = generate_test_dset(nlat=2, nlon=2)
     out = cmp.same_spatial_grid(


### PR DESCRIPTION
# Description

Fix for a bug when running the `amoc-RAPID` diagnostic test-case in the REF.

The RAPID observations (129 months) and the model (130 months) differ by one step.
When the trimmed series disagree in length, this intersects the monthly datasets on their (year, month) keys so equal-length, month-aligned series are returned. 

THis assumes at most one timestep per month.
