### PR TITLE
FIX: allow the target time frequency to be given in the configure

### DIFF
--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -354,7 +354,7 @@ def run_single_block(
         # Load the comparison data
         try:
             # Match the reference time frequency if possible
-            cmip_time_lbl = ild.get_frequency_label(ref)
+            cmip_time_lbl = setup.get("target_time_freq", ild.get_frequency_label(ref))
             grp = ill.match_frequency(grp, cmip_time_lbl)
             com = ill.load_comparison_data(
                 grp,


### PR DESCRIPTION
The automatic detection of reference data time frequency operates on the resultant dataset from `ilamb3.load.load_reference()`. If that process takes daily reference data and returns, say, monthly data via transforms, then ilamb3 will infer that the desired frequency is monthly. In these cases, shown below, we just need to give what the `target_time_freq` is which will skip the calculation.

```yaml
Extremes:
  Wet Days:
    Daymet-4-1:
      analysis_variable: wet_days
      target_time_freq: day    # <-- new addition
      sources:
        prcp: /home/nate/work/ilamb3/_daymet/DaymetV4_VIC4_prcp_198*.nc
      transforms:
        - rename:
            prcp: pr
        - count_wet_days
```