### PR TITLE
FIX: parallel execution silent crash

### DIFF
--- a/ilamb3/analysis/runoff_sensitivity.py
+++ b/ilamb3/analysis/runoff_sensitivity.py
@@ -63,7 +63,7 @@ class runoff_sensitivity_analysis(ILAMBAnalysis):
         # Register basins in the ILAMB region system
         self.basins = list(
             set(
-                ilr.Regions().add_netcdf(
+                ilr.Regions().add_region_netcdf(
                     ill.load_key_or_filename("G-RUN/mrb_basins.nc")
                 )
             )

--- a/ilamb3/parallel.py
+++ b/ilamb3/parallel.py
@@ -225,7 +225,12 @@ def _start_worker(cfg_path: Path):
     ilamb3.conf.load(cfg_path)
     ilamb_regions = ilr.Regions()
     for source in ilamb3.conf["region_sources"]:
-        ilamb_regions.add_netcdf(ill.load_key_or_filename(source))
+        if source.endswith(".nc"):
+            ilamb_regions.add_region_netcdf(ill.load_key_or_filename(str(source)))
+        elif source.endswith(".yaml") or source.endswith(".yml"):
+            ilamb_regions.add_region_yaml(source)
+        else:
+            raise ValueError("Unrecognized region file format.")
 
 
 def run_study_parallel(

--- a/ilamb3/run.py
+++ b/ilamb3/run.py
@@ -215,7 +215,7 @@ def augment_setup_with_options(
                     reference_data.loc[ilamb3.conf["quantile_database"], "path"]
                 )
                 setup["quantile_threshold"] = ilamb3.conf["quantile_threshold"]
-                ilr.Regions().add_netcdf(
+                ilr.Regions().add_region_netcdf(
                     xr.load_dataset(reference_data.loc["regions/Whittaker.nc", "path"])
                 )
             except Exception:


### PR DESCRIPTION
In order to pass global state configuration information to threads, we pass a `_start_worker()` function to `MPIPoolExecutor` that reads the state from a file. Inside this function we called a member function of our regions that does not exist after the rework. It was not tested because our parallel execution is designed to happen if `mpi4py` is installed and I do not have a mechanism for testing based on what we find installed.
